### PR TITLE
Major rework of the MemCNN core and API

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,16 @@
 History
 =======
 
+1.1.0 (2019-12-15)
+------------------
+
+* A complete refactor of MemCNN with changes to the API
+  * Factored out the code responsible for the memory savings in a separate InvertibleModuleWrapper and reimplemented it using hooks
+  * The InvertibleModuleWrapper allows for arbitrary invertible functions now (not just the additive and affine couplings)
+  * The AdditiveBlock and AffineBlock have been refactored to AdditiveCoupling and AffineCoupling
+  * The ReveribleBlock is now deprecated
+  * The documentation and examples have been updated for the new API changes
+
 1.0.1 (2019-12-08)
 ------------------
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,8 @@ RUN usermod -a -G sudo user
 
 # Install necessary python libraries
 RUN python3.6 -m pip install pip --upgrade
+RUN python3.6 -m pip install https://download.pytorch.org/whl/cu100/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
+RUN python3.6 -m pip install https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
 RUN python3.6 -m pip install memcnn
 
 # Set MemCNN config file for user environement

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,19 +7,20 @@ To use MemCNN in a project::
     import memcnn
 
 
-Example usage: ReversibleBlock
-------------------------------
+Examples
+--------
+
+Creating an AdditiveCoupling with memory savings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: python
 
-    # some required imports
     import torch
     import torch.nn as nn
-    import numpy as np
     import memcnn
 
 
-    # define a new class of operation(s) PyTorch style
+    # define a new torch Module with a sequence of operations: Relu o BatchNorm2d o Conv2d
     class ExampleOperation(nn.Module):
         def __init__(self, channels):
             super(ExampleOperation, self).__init__()
@@ -34,17 +35,42 @@ Example usage: ReversibleBlock
             return self.seq(x)
 
 
-    # generate some random input data (b, c, y, x)
-    data = np.random.random((2, 10, 8, 8)).astype(np.float32)
-    X = torch.from_numpy(data)
+    # generate some random input data (batch_size, num_channels, y_elements, x_elements)
+    X = torch.rand(2, 10, 8, 8)
 
     # application of the operation(s) the normal way
-    Y = ExampleOperation(channels=10)(X)
+    model_normal = ExampleOperation(channels=10)
+    model_normal.eval()
 
-    # application of the operation(s) using the reversible block
-    F, G = ExampleOperation(channels=10 // 2), ExampleOperation(channels=10 // 2)
-    Y = memcnn.ReversibleBlock(F, G, coupling='additive')(X)
+    Y = model_normal(X)
 
+    # turn the ExampleOperation invertible using an additive coupling
+    invertible_module = memcnn.AdditiveCoupling(
+        Fm=ExampleOperation(channels=10 // 2),
+        Gm=ExampleOperation(channels=10 // 2)
+    )
+
+    # test that it is actually a valid invertible module (has a valid inverse method)
+    assert memcnn.is_invertible_module(invertible_module, test_input_shape=X.shape)
+
+    # wrap our invertible_module using the InvertibleModuleWrapper and benefit from memory savings during training
+    invertible_module_wrapper = memcnn.InvertibleModuleWrapper(fn=invertible_module, keep_input=True, keep_input_inverse=True)
+
+    # by default the module is set to training, the following sets this to evaluation
+    # note that this is required to pass input tensors to the model with requires_grad=False (inference only)
+    invertible_module_wrapper.eval()
+
+    # test that the wrapped module is also a valid invertible module
+    assert memcnn.is_invertible_module(invertible_module_wrapper, test_input_shape=X.shape)
+
+    # compute the forward pass using the wrapper
+    Y2 = invertible_module_wrapper.forward(X)
+
+    # the input (X) can be approximated (X2) by applying the inverse method of the wrapper on Y2
+    X2 = invertible_module_wrapper.inverse(Y2)
+
+    # test that the input and approximation are similar
+    assert torch.allclose(X, X2, atol=1e-06)
 
 Run PyTorch Experiments
 -----------------------

--- a/memcnn/__init__.py
+++ b/memcnn/__init__.py
@@ -7,11 +7,17 @@ __email__ = 'silvandeleemput@gmail.com'
 __version__ = '1.0.1'
 
 
-from memcnn.models.revop import ReversibleBlock, ReversibleModule, create_coupling, is_invertible_module
+from memcnn.models.revop import ReversibleBlock, InvertibleModuleWrapper, create_coupling, is_invertible_module
+from memcnn.models.additive import AdditiveCoupling
+from memcnn.models.affine import AffineCoupling, AffineAdapterNaive, AffineAdapterSigmoid
 
 __all__ = [
+    'AdditiveCoupling',
+    'AffineCoupling',
+    'AffineAdapterNaive',
+    'AffineAdapterSigmoid',
+    'InvertibleModuleWrapper',
     'ReversibleBlock',
-    'ReversibleModule',
     'create_coupling',
     'is_invertible_module'
 ]

--- a/memcnn/__init__.py
+++ b/memcnn/__init__.py
@@ -7,8 +7,9 @@ __email__ = 'silvandeleemput@gmail.com'
 __version__ = '1.0.1'
 
 
-from memcnn.models.revop import ReversibleBlock
+from memcnn.models.revop import ReversibleBlock, ReversibleModule
 
 __all__ = [
-    'ReversibleBlock'
+    'ReversibleBlock',
+    'ReversibleModule'
 ]

--- a/memcnn/__init__.py
+++ b/memcnn/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Sil van de Leemput"""
 __email__ = 'silvandeleemput@gmail.com'
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 
 from memcnn.models.revop import ReversibleBlock, InvertibleModuleWrapper, create_coupling, is_invertible_module

--- a/memcnn/__init__.py
+++ b/memcnn/__init__.py
@@ -7,9 +7,10 @@ __email__ = 'silvandeleemput@gmail.com'
 __version__ = '1.0.1'
 
 
-from memcnn.models.revop import ReversibleBlock, ReversibleModule
+from memcnn.models.revop import ReversibleBlock, ReversibleModule, create_coupling
 
 __all__ = [
     'ReversibleBlock',
-    'ReversibleModule'
+    'ReversibleModule',
+    'create_coupling'
 ]

--- a/memcnn/__init__.py
+++ b/memcnn/__init__.py
@@ -7,10 +7,11 @@ __email__ = 'silvandeleemput@gmail.com'
 __version__ = '1.0.1'
 
 
-from memcnn.models.revop import ReversibleBlock, ReversibleModule, create_coupling
+from memcnn.models.revop import ReversibleBlock, ReversibleModule, create_coupling, is_invertible_module
 
 __all__ = [
     'ReversibleBlock',
     'ReversibleModule',
-    'create_coupling'
+    'create_coupling',
+    'is_invertible_module'
 ]

--- a/memcnn/examples/minimal.py
+++ b/memcnn/examples/minimal.py
@@ -27,19 +27,30 @@ model_normal.eval()
 
 Y = model_normal(X)
 
-# application of the ExampleOperation turned invertible using an additive coupling
-F = ExampleOperation(channels=10 // 2)
-invertible_function = memcnn.create_coupling(Fm=F, coupling='additive')
+# turn the ExampleOperation invertible using an additive coupling
+invertible_module = memcnn.AdditiveCoupling(
+    Fm=ExampleOperation(channels=10 // 2),
+    Gm=ExampleOperation(channels=10 // 2)
+)
 
-# the ReversibleModule can wrap invertible functions and
-# can free memory using the invertible property during training and inference
-model_invertible = memcnn.ReversibleModule(fn=invertible_function, keep_input=True, keep_input_inverse=True)
-model_invertible.eval()  # This is required for any input tensor to the model with requires_grad=True (inference only)
-Y2 = model_invertible(X)
+# test that it is actually a valid invertible module (has a valid inverse method)
+assert memcnn.is_invertible_module(invertible_module, test_input_shape=X.shape)
 
-# The input (X) can be approximated (X2) by applying the inverse method of the reversible block on Y2
-X2 = model_invertible.inverse(Y2)
+# wrap our invertible_module using the InvertibleModuleWrapper and benefit from memory savings during training
+invertible_module_wrapper = memcnn.InvertibleModuleWrapper(fn=invertible_module, keep_input=True, keep_input_inverse=True)
+
+# by default the module is set to training, the following sets this to evaluation
+# note that this is required to pass input tensors to the model with requires_grad=False (inference only)
+invertible_module_wrapper.eval()
+
+# test that the wrapped module is also a valid invertible module
+assert memcnn.is_invertible_module(invertible_module_wrapper, test_input_shape=X.shape)
+
+# compute the forward pass using the wrapper
+Y2 = invertible_module_wrapper.forward(X)
+
+# the input (X) can be approximated (X2) by applying the inverse method of the wrapper on Y2
+X2 = invertible_module_wrapper.inverse(Y2)
+
+# test that the input and approximation are similar
 assert torch.allclose(X, X2, atol=1e-06)
-
-# Output of the reversible block is unlikely to match the normal output of F
-assert not torch.allclose(Y2, Y)

--- a/memcnn/examples/minimal.py
+++ b/memcnn/examples/minimal.py
@@ -22,11 +22,18 @@ X = torch.rand(2, 10, 8, 8)
 
 # application of the operation(s) the normal way
 model_normal = ExampleOperation(channels=10)
+model_normal.eval()
+
 Y = model_normal(X)
 
-# application of the operation(s) turned invertible using the reversible block
+# application of the ExampleOperation turned invertible using an additive coupling
 F = ExampleOperation(channels=10 // 2)
-model_invertible = memcnn.ReversibleBlock(F, coupling='additive', keep_input=True, keep_input_inverse=True)
+invertible_function = memcnn.create_coupling(Fm=F, coupling='additive')
+
+# the ReversibleModule can wrap invertible functions and
+# can free memory using the invertible property during training and inference
+model_invertible = memcnn.ReversibleModule(fn=invertible_function, keep_input=True, keep_input_inverse=True)
+model_invertible.eval()  # This is required for any input tensor to the model with requires_grad=True (inference only)
 Y2 = model_invertible(X)
 
 # The input (X) can be approximated (X2) by applying the inverse method of the reversible block on Y2

--- a/memcnn/examples/minimal.py
+++ b/memcnn/examples/minimal.py
@@ -17,6 +17,7 @@ class ExampleOperation(nn.Module):
     def forward(self, x):
         return self.seq(x)
 
+
 # generate some random input data (batch_size, num_channels, y_elements, x_elements)
 X = torch.rand(2, 10, 8, 8)
 

--- a/memcnn/examples/test_examples.py
+++ b/memcnn/examples/test_examples.py
@@ -7,13 +7,12 @@ def test_minimal():
     # Input and inversed output should be approximately the same
     assert torch.allclose(minimal.X, minimal.X2, atol=1e-06)
 
-    # Output of the reversible block is unlikely to match the normal output of F
+    # Output of the wrapped invertible module is unlikely to match the normal output of F
     assert not torch.allclose(minimal.Y2, minimal.Y)
 
     # Cleanup minimal module and variables
     del minimal.X
     del minimal.Y
-    del minimal.F
     del minimal.Y2
     del minimal.X2
     del minimal

--- a/memcnn/models/additive.py
+++ b/memcnn/models/additive.py
@@ -2,7 +2,6 @@ import torch
 import torch.nn as nn
 import copy
 from torch import set_grad_enabled
-import warnings
 import numpy as np
 
 
@@ -47,7 +46,6 @@ class AdditiveBlock(nn.Module):
         elif self.implementation_fwd == 1:
             out = AdditiveBlockFunction2.apply(*args)
         elif self.implementation_fwd == -1:
-            warnings.warn('Using direct non-memory saving implementation.', NonMemorySavingWarning)
             x1, x2 = torch.chunk(x, 2, dim=1)
             x1, x2 = x1.contiguous(), x2.contiguous()
             fmd = self.Fm.forward(x2)

--- a/memcnn/models/additive.py
+++ b/memcnn/models/additive.py
@@ -1,3 +1,4 @@
+import warnings
 import torch
 import torch.nn as nn
 import copy
@@ -5,12 +6,8 @@ from torch import set_grad_enabled
 import numpy as np
 
 
-class NonMemorySavingWarning(UserWarning):
-    pass
-
-
-class AdditiveBlock(nn.Module):
-    def __init__(self, Fm, Gm=None, implementation_fwd=1, implementation_bwd=1):
+class AdditiveCoupling(nn.Module):
+    def __init__(self, Fm, Gm=None, implementation_fwd=-1, implementation_bwd=-1):
         """The AdditiveBlock
 
         Parameters
@@ -29,7 +26,7 @@ class AdditiveBlock(nn.Module):
                 Switch between different Additive Operation implementations for inverse pass. Default = 1
 
         """
-        super(AdditiveBlock, self).__init__()
+        super(AdditiveCoupling, self).__init__()
         # mirror the passed module, without parameter sharing...
         if Gm is None:
             Gm = copy.deepcopy(Fm)
@@ -79,6 +76,15 @@ class AdditiveBlock(nn.Module):
                                       .format(self.implementation_bwd))
 
         return x
+
+
+class AdditiveBlock(AdditiveCoupling):
+    def __init__(self, Fm, Gm=None, implementation_fwd=1, implementation_bwd=1):
+        warnings.warn("This class has been deprecated. Use the AdditiveCoupling class instead.",
+                      DeprecationWarning)
+        super(AdditiveBlock, self).__init__(Fm=Fm, Gm=Gm,
+                                            implementation_fwd=implementation_fwd,
+                                            implementation_bwd=implementation_bwd)
 
 
 class AdditiveBlockFunction(torch.autograd.Function):

--- a/memcnn/models/additive.py
+++ b/memcnn/models/additive.py
@@ -3,7 +3,6 @@ import torch
 import torch.nn as nn
 import copy
 from torch import set_grad_enabled
-import numpy as np
 
 
 class AdditiveCoupling(nn.Module):
@@ -34,6 +33,9 @@ class AdditiveCoupling(nn.Module):
         self.Fm = Fm
         self.implementation_fwd = implementation_fwd
         self.implementation_bwd = implementation_bwd
+        if implementation_bwd != -1 or implementation_fwd != -1:
+            warnings.warn("Other implementations than the default (-1) are now deprecated.",
+                          DeprecationWarning)
 
     def forward(self, x):
         args = [x, self.Fm, self.Gm] + [w for w in self.Fm.parameters()] + [w for w in self.Gm.parameters()]
@@ -53,7 +55,6 @@ class AdditiveCoupling(nn.Module):
         else:
             raise NotImplementedError("Selected implementation ({}) not implemented..."
                                       .format(self.implementation_fwd))
-
         return out
 
     def inverse(self, y):
@@ -74,7 +75,6 @@ class AdditiveCoupling(nn.Module):
         else:
             raise NotImplementedError("Inverse for selected implementation ({}) not implemented..."
                                       .format(self.implementation_bwd))
-
         return x
 
 
@@ -89,7 +89,7 @@ class AdditiveBlock(AdditiveCoupling):
 
 class AdditiveBlockFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, Fm, Gm, *weights):
+    def forward(ctx, xin, Fm, Gm, *weights):
         """Forward pass for the reversible block computes:
         {x1, x2} = x
         y1 = x1 + Fm(x2)
@@ -116,13 +116,14 @@ class AdditiveBlockFunction(torch.autograd.Function):
 
         """
         # check if possible to partition into two equally sized partitions
-        assert(x.shape[1] % 2 == 0)  # nosec
+        assert(xin.shape[1] % 2 == 0)  # nosec
 
         # store partition size, Fm and Gm functions in context
         ctx.Fm = Fm
         ctx.Gm = Gm
 
         with torch.no_grad():
+            x = xin.detach()
             # partition in two equally sized set of channels
             x1, x2 = torch.chunk(x, 2, dim=1)
             x1, x2 = x1.contiguous(), x2.contiguous()
@@ -138,12 +139,8 @@ class AdditiveBlockFunction(torch.autograd.Function):
             x2.set_()
             del x2
             output = torch.cat([y1, y2], dim=1)
-            y1.set_()
-            y2.set_()
-            del y1, y2
 
-        # save the (empty) input and (non-empty) output variables
-        ctx.save_for_backward(x.data, output)
+        ctx.save_for_backward(xin, output)
 
         return output
 
@@ -153,23 +150,17 @@ class AdditiveBlockFunction(torch.autograd.Function):
         Fm, Gm = ctx.Fm, ctx.Gm
 
         # retrieve input and output references
-        x, output = ctx.saved_tensors
-        y1, y2 = torch.chunk(output, 2, dim=1)
-        y1, y2 = y1.contiguous(), y2.contiguous()
-
+        xin, output = ctx.saved_tensors
+        x = xin.detach()
+        x1, x2 = torch.chunk(x, 2, dim=1)
+        GWeights = [p for p in Gm.parameters()]
         # partition output gradient also on channels
-        assert(grad_output.shape[1] % 2 == 0)  # nosec
-
-        with torch.no_grad():
-            # recompute x
-            GWeights = [p for p in Gm.parameters()]
-            x2 = y2 - Gm.forward(y1)
-            x1 = y1 - Fm.forward(x2)
+        assert grad_output.shape[1] % 2 == 0  # nosec
 
         with set_grad_enabled(True):
             # compute outputs building a sub-graph
-            x1.requires_grad = True
-            x2.requires_grad = True
+            x1.requires_grad_()
+            x2.requires_grad_()
 
             y1 = x1 + Fm.forward(x2)
             y2 = x2 + Gm.forward(y1)
@@ -181,17 +172,6 @@ class AdditiveBlockFunction(torch.autograd.Function):
             GWgrads = dd[2:2+len(GWeights)]
             FWgrads = dd[2+len(GWeights):]
             grad_input = torch.cat([dd[0], dd[1]], dim=1)
-
-            # cleanup sub-graph
-            y1.detach_()
-            y2.detach_()
-            del y1, y2
-
-        # restore input
-        xout = torch.cat([x1, x2], dim=1).contiguous()
-        with torch.no_grad():
-            x.storage().resize_(int(np.prod(xout.shape)))
-            x.set_(xout)
 
         return (grad_input, None, None) + FWgrads + GWgrads
 
@@ -262,19 +242,13 @@ class AdditiveBlockInverseFunction(torch.autograd.Function):
         Fm, Gm = cty.Fm, cty.Gm
 
         # retrieve input and output references
-        y, output = cty.saved_tensors
-        x1, x2 = torch.chunk(output, 2, dim=1)
-        x1, x2 = x1.contiguous(), x2.contiguous()
+        yin, output = cty.saved_tensors
+        y = yin.detach()
+        y1, y2 = torch.chunk(y, 2, dim=1)
+        FWeights = [p for p in Fm.parameters()]
 
         # partition output gradient also on channels
-        assert(grad_output.shape[1] % 2 == 0)  # nosec
-
-        with torch.no_grad():
-            # recompute y
-            FWeights = [p for p in Fm.parameters()]
-            y1 = x1 + Fm.forward(x2)
-            y2 = x2 + Gm.forward(y1)
-
+        assert grad_output.shape[1] % 2 == 0  # nosec
 
         with set_grad_enabled(True):
             # compute outputs building a sub-graph
@@ -292,22 +266,11 @@ class AdditiveBlockInverseFunction(torch.autograd.Function):
             GWgrads = dd[2+len(FWeights):]
             grad_input = torch.cat([dd[0], dd[1]], dim=1)
 
-            # cleanup sub-graph
-            x1.detach_()
-            x2.detach_()
-            del x1, x2
-
-        # restore input
-        yout = torch.cat([y1, y2], dim=1).contiguous()
-        with torch.no_grad():
-            x.storage().resize_(int(np.prod(yout.shape)))
-            y.set_(yout)
-
         return (grad_input, None, None) + FWgrads + GWgrads
 
 class AdditiveBlockFunction2(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, Fm, Gm, *weights):
+    def forward(ctx, xin, Fm, Gm, *weights):
         """Forward pass for the reversible block computes:
         {x1, x2} = x
         y1 = x1 + Fm(x2)
@@ -334,7 +297,7 @@ class AdditiveBlockFunction2(torch.autograd.Function):
 
         """
         # check if possible to partition into two equally sized partitions
-        assert(x.shape[1] % 2 == 0)  # nosec
+        assert xin.shape[1] % 2 == 0  # nosec
 
         # store partition size, Fm and Gm functions in context
         ctx.Fm = Fm
@@ -342,6 +305,7 @@ class AdditiveBlockFunction2(torch.autograd.Function):
 
         with torch.no_grad():
             # partition in two equally sized set of channels
+            x = xin.detach()
             x1, x2 = torch.chunk(x, 2, dim=1)
             x1, x2 = x1.contiguous(), x2.contiguous()
 
@@ -355,14 +319,10 @@ class AdditiveBlockFunction2(torch.autograd.Function):
             y2 = x2 + gmr
             x2.set_()
             del x2
-            output = torch.cat([y1, y2], dim=1)
-            y1.set_()
-            del y1
-            y2.set_()
-            del y2
+            output = torch.cat([y1, y2], dim=1).detach_()
 
         # save the input and output variables
-        ctx.save_for_backward(x.data, output)
+        ctx.save_for_backward(x, output)
 
         return output
 
@@ -399,12 +359,6 @@ class AdditiveBlockFunction2(torch.autograd.Function):
             x1_stop = x1.detach()
             x1_stop.requires_grad = True
 
-            # restore input
-            xout = torch.cat([x1, x2], dim=1).contiguous()
-            with torch.no_grad():
-                x.storage().resize_(int(np.prod(xout.shape)))
-                x.set_(xout).detach()  # NOTE .detach() is very important here.
-
             # compute outputs building a sub-graph
             y1 = x1_stop + F_x2
             y2 = x2_stop + G_z1
@@ -420,10 +374,6 @@ class AdditiveBlockFunction2(torch.autograd.Function):
             x2_grad = dd[1] + y2_grad
             x1_grad = dd[0]
             grad_input = torch.cat([x1_grad, x2_grad], dim=1)
-
-            y1.detach_()
-            y2.detach_()
-            del y1, y2
 
         return (grad_input, None, None) + FWgrads + GWgrads
 
@@ -478,14 +428,10 @@ class AdditiveBlockInverseFunction2(torch.autograd.Function):
             x1 = y1 - fmr
             y1.set_()
             del y1
-            output = torch.cat([x1, x2], dim=1)
-            x1.set_()
-            del x1
-            x2.set_()
-            del x2
+            output = torch.cat([x1, x2], dim=1).detach_()
 
         # save the input and output variables
-        cty.save_for_backward(y.data, output)
+        cty.save_for_backward(y, output)
 
         return output
 
@@ -522,12 +468,6 @@ class AdditiveBlockInverseFunction2(torch.autograd.Function):
             y2_stop = y2.detach()
             y2_stop.requires_grad = True
 
-            # restore input
-            yout = torch.cat([y1, y2], dim=1).contiguous()
-            with torch.no_grad():
-                y.storage().resize_(int(np.prod(yout.shape)))
-                y.set_(yout).detach()  # NOTE .detach() is very important here.
-
             # compute outputs building a sub-graph
             z1 = y2_stop - G_y1
             x1 = y1_stop - F_z1
@@ -545,9 +485,5 @@ class AdditiveBlockInverseFunction2(torch.autograd.Function):
             y2_grad = dd[0]
 
             grad_input = torch.cat([y1_grad, y2_grad], dim=1)
-
-            x1.detach_()
-            x2.detach_()
-            del x1, x2
 
         return (grad_input, None, None) + FWgrads + GWgrads

--- a/memcnn/models/additive.py
+++ b/memcnn/models/additive.py
@@ -90,7 +90,7 @@ class AdditiveBlock(AdditiveCoupling):
 class AdditiveBlockFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, xin, Fm, Gm, *weights):
-        """Forward pass for the reversible block computes:
+        """Forward pass computes:
         {x1, x2} = x
         y1 = x1 + Fm(x2)
         y2 = x2 + Gm(y1)
@@ -98,7 +98,7 @@ class AdditiveBlockFunction(torch.autograd.Function):
 
         Parameters
         ----------
-        ctx : torch.autograd.function.RevNetFunctionBackward
+        ctx : torch.autograd.Function
             The backward pass context object
         x : TorchTensor
             Input tensor. Must have channels (2nd dimension) that can be partitioned in two equal partitions
@@ -179,7 +179,7 @@ class AdditiveBlockFunction(torch.autograd.Function):
 class AdditiveBlockInverseFunction(torch.autograd.Function):
     @staticmethod
     def forward(cty, y, Fm, Gm, *weights):
-        """Forward pass for the reversible block computes:
+        """Forward pass computes:
         {y1, y2} = y
         x2 = y2 - Gm(y1)
         x1 = y1 - Fm(x2)
@@ -187,7 +187,7 @@ class AdditiveBlockInverseFunction(torch.autograd.Function):
 
         Parameters
         ----------
-        cty : torch.autograd.function.RevNetInverseFunctionBackward
+        cty : torch.autograd.Function
             The backward pass context object
         y : TorchTensor
             Input tensor. Must have channels (2nd dimension) that can be partitioned in two equal partitions
@@ -271,7 +271,7 @@ class AdditiveBlockInverseFunction(torch.autograd.Function):
 class AdditiveBlockFunction2(torch.autograd.Function):
     @staticmethod
     def forward(ctx, xin, Fm, Gm, *weights):
-        """Forward pass for the reversible block computes:
+        """Forward pass computes:
         {x1, x2} = x
         y1 = x1 + Fm(x2)
         y2 = x2 + Gm(y1)
@@ -279,7 +279,7 @@ class AdditiveBlockFunction2(torch.autograd.Function):
 
         Parameters
         ----------
-        ctx : torch.autograd.function.RevNetFunctionBackward
+        ctx : torch.autograd.Function
             The backward pass context object
         x : TorchTensor
             Input tensor. Must have channels (2nd dimension) that can be partitioned in two equal partitions
@@ -381,7 +381,7 @@ class AdditiveBlockFunction2(torch.autograd.Function):
 class AdditiveBlockInverseFunction2(torch.autograd.Function):
     @staticmethod
     def forward(cty, y, Fm, Gm, *weights):
-        """Forward pass for the reversible block computes:
+        """Forward pass computes:
         {y1, y2} = y
         x2 = y2 - Gm(y1)
         x1 = y1 - Fm(x2)
@@ -389,7 +389,7 @@ class AdditiveBlockInverseFunction2(torch.autograd.Function):
 
         Parameters
         ----------
-        cty : torch.autograd.function.RevNetInverseFunctionBackward
+        cty : torch.autograd.Function
             The backward pass context object
         y : TorchTensor
             Input tensor. Must have channels (2nd dimension) that can be partitioned in two equal partitions

--- a/memcnn/models/affine.py
+++ b/memcnn/models/affine.py
@@ -41,8 +41,8 @@ class AffineAdapterSigmoid(nn.Module):
         return scale, shift
 
 
-class AffineBlock(nn.Module):
-    def __init__(self, Fm, Gm=None, adapter=None, implementation_fwd=1, implementation_bwd=1):
+class AffineCoupling(nn.Module):
+    def __init__(self, Fm, Gm=None, adapter=None, implementation_fwd=-1, implementation_bwd=-1):
         """The AffineBlock
 
         Parameters
@@ -60,13 +60,13 @@ class AffineBlock(nn.Module):
                 s, t are respectively the scale and shift tensors for the affine coupling.
 
             implementation_fwd : int
-                Switch between different Affine Operation implementations for forward pass. Default = 1
+                Switch between different Affine Operation implementations for forward pass. Default = -1
 
             implementation_bwd : int
-                Switch between different Affine Operation implementations for inverse pass. Default = 1
+                Switch between different Affine Operation implementations for inverse pass. Default = -1
 
         """
-        super(AffineBlock, self).__init__()
+        super(AffineCoupling, self).__init__()
         # mirror the passed module, without parameter sharing...
         if Gm is None:
             Gm = copy.deepcopy(Fm)
@@ -117,6 +117,15 @@ class AffineBlock(nn.Module):
                                       .format(self.implementation_bwd))
 
         return x
+
+
+class AffineBlock(AffineCoupling):
+    def __init__(self, Fm, Gm=None, implementation_fwd=1, implementation_bwd=1):
+        warnings.warn("This class has been deprecated. Use the AffineCoupling class instead.",
+                      DeprecationWarning)
+        super(AffineBlock, self).__init__(Fm=Fm, Gm=Gm,
+                                          implementation_fwd=implementation_fwd,
+                                          implementation_bwd=implementation_bwd)
 
 
 class AffineBlockFunction(torch.autograd.Function):

--- a/memcnn/models/affine.py
+++ b/memcnn/models/affine.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 import copy
 import warnings
 from torch import set_grad_enabled
-import numpy as np
 
 warnings.filterwarnings(action='ignore', category=UserWarning)
 
@@ -75,6 +74,9 @@ class AffineCoupling(nn.Module):
         self.Fm = adapter(Fm) if adapter is not None else Fm
         self.implementation_fwd = implementation_fwd
         self.implementation_bwd = implementation_bwd
+        if implementation_bwd != -1 or implementation_fwd != -1:
+            warnings.warn("Other implementations than the default (-1) are now deprecated.",
+                          DeprecationWarning)
 
     def forward(self, x):
         args = [x, self.Fm, self.Gm] + [w for w in self.Fm.parameters()] + [w for w in self.Gm.parameters()]
@@ -94,7 +96,6 @@ class AffineCoupling(nn.Module):
         else:
             raise NotImplementedError("Selected implementation ({}) not implemented..."
                                       .format(self.implementation_fwd))
-
         return out
 
     def inverse(self, y):
@@ -115,7 +116,6 @@ class AffineCoupling(nn.Module):
         else:
             raise NotImplementedError("Inverse for selected implementation ({}) not implemented..."
                                       .format(self.implementation_bwd))
-
         return x
 
 
@@ -130,7 +130,7 @@ class AffineBlock(AffineCoupling):
 
 class AffineBlockFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, Fm, Gm, *weights):
+    def forward(ctx, xin, Fm, Gm, *weights):
         """Forward pass for the affine block computes:
         {x1, x2} = x
         {log_s1, t1} = Fm(x2)
@@ -161,7 +161,7 @@ class AffineBlockFunction(torch.autograd.Function):
 
         """
         # check if possible to partition into two equally sized partitions
-        assert (x.shape[1] % 2 == 0)  # nosec
+        assert xin.shape[1] % 2 == 0  # nosec
 
         # store partition size, Fm and Gm functions in context
         ctx.Fm = Fm
@@ -169,6 +169,7 @@ class AffineBlockFunction(torch.autograd.Function):
 
         with torch.no_grad():
             # partition in two equally sized set of channels
+            x = xin.detach()
             x1, x2 = torch.chunk(x, 2, dim=1)
             x1, x2 = x1.contiguous(), x2.contiguous()
 
@@ -184,13 +185,10 @@ class AffineBlockFunction(torch.autograd.Function):
             y2 = (x2 * gmr1) + gmr2
             x2.set_()
             del x2
-            output = torch.cat([y1, y2], dim=1)
-            y1.set_()
-            y2.set_()
-            del y1, y2
+            output = torch.cat([y1, y2], dim=1).detach_()
 
         # save the (empty) input and (non-empty) output variables
-        ctx.save_for_backward(x.data, output)
+        ctx.save_for_backward(xin, output)
 
         return output
 
@@ -200,22 +198,13 @@ class AffineBlockFunction(torch.autograd.Function):
         Fm, Gm = ctx.Fm, ctx.Gm
 
         # retrieve input and output references
-        x, output = ctx.saved_tensors
-        y1, y2 = torch.chunk(output, 2, dim=1)
-        y1, y2 = y1.contiguous(), y2.contiguous()
+        xin, output = ctx.saved_tensors
+        x = xin.detach()
+        x1, x2 = torch.chunk(x.detach(), 2, dim=1)
+        GWeights = [p for p in Gm.parameters()]
 
         # partition output gradient also on channels
         assert (grad_output.shape[1] % 2 == 0)  # nosec
-
-        with set_grad_enabled(False):
-            # recompute x
-            z1_stop = y1
-            z1_stop.requires_grad = True
-            GWeights = [p for p in Gm.parameters()]
-            gmr1, gmr2 = Gm.forward(z1_stop)
-            x2 = (y2 - gmr2) / gmr1
-            fmr1, fmr2 = Fm.forward(x2)
-            x1 = (y1 - fmr2) / fmr1
 
         with set_grad_enabled(True):
             # compute outputs building a sub-graph
@@ -235,23 +224,12 @@ class AffineBlockFunction(torch.autograd.Function):
             FWgrads = dd[2 + len(GWeights):]
             grad_input = torch.cat([dd[0], dd[1]], dim=1)
 
-            # cleanup sub-graph
-            y1.detach_()
-            y2.detach_()
-            del y1, y2
-
-        # restore input
-        xout = torch.cat([x1, x2], dim=1).contiguous()
-        with torch.no_grad():
-            x.storage().resize_(int(np.prod(xout.shape)))
-            x.set_(xout)
-
         return (grad_input, None, None) + FWgrads + GWgrads
 
 
 class AffineBlockInverseFunction(torch.autograd.Function):
     @staticmethod
-    def forward(cty, y, Fm, Gm, *weights):
+    def forward(cty, yin, Fm, Gm, *weights):
         """Forward inverse pass for the affine block computes:
         {y1, y2} = y
         {log_s2, t2} = Gm(y1)
@@ -282,7 +260,7 @@ class AffineBlockInverseFunction(torch.autograd.Function):
 
         """
         # check if possible to partition into two equally sized partitions
-        assert (y.shape[1] % 2 == 0)  # nosec
+        assert yin.shape[1] % 2 == 0  # nosec
 
         # store partition size, Fm and Gm functions in context
         cty.Fm = Fm
@@ -290,6 +268,7 @@ class AffineBlockInverseFunction(torch.autograd.Function):
 
         with torch.no_grad():
             # partition in two equally sized set of channels
+            y = yin.detach()
             y1, y2 = torch.chunk(y, 2, dim=1)
             y1, y2 = y1.contiguous(), y2.contiguous()
 
@@ -307,13 +286,10 @@ class AffineBlockInverseFunction(torch.autograd.Function):
             x1 = (y1 - fmr2) / fmr1
             y1.set_()
             del y1
-            output = torch.cat([x1, x2], dim=1)
-            x1.set_()
-            x2.set_()
-            del x1, x2
+            output = torch.cat([x1, x2], dim=1).detach_()
 
-        # save the (empty) input and (non-empty) output variables
-        cty.save_for_backward(y.data, output)
+        # save input and output variables
+        cty.save_for_backward(yin, output)
 
         return output
 
@@ -323,22 +299,13 @@ class AffineBlockInverseFunction(torch.autograd.Function):
         Fm, Gm = cty.Fm, cty.Gm
 
         # retrieve input and output references
-        y, output = cty.saved_tensors
-        x1, x2 = torch.chunk(output, 2, dim=1)
-        x1, x2 = x1.contiguous(), x2.contiguous()
+        yin, output = cty.saved_tensors
+        y = yin.detach()
+        y1, y2 = torch.chunk(y.detach(), 2, dim=1)
+        FWeights = [p for p in Gm.parameters()]
 
         # partition output gradient also on channels
-        assert (grad_output.shape[1] % 2 == 0)  # nosec
-
-        with set_grad_enabled(False):
-            # recompute y
-            z1_stop = x2
-            z1_stop.requires_grad = True
-            FWeights = [p for p in Fm.parameters()]
-            fmr1, fmr2 = Fm.forward(z1_stop)
-            y1 = (fmr1 * x1) + fmr2
-            gmr1, gmr2 = Gm.forward(y1)
-            y2 = (gmr1 * x2) + gmr2
+        assert grad_output.shape[1] % 2 == 0  # nosec
 
         with set_grad_enabled(True):
             # compute outputs building a sub-graph
@@ -358,23 +325,12 @@ class AffineBlockInverseFunction(torch.autograd.Function):
             GWgrads = dd[2 + len(FWeights):]
             grad_input = torch.cat([dd[0], dd[1]], dim=1)
 
-            # cleanup sub-graph
-            x1.detach_()
-            x2.detach_()
-            del x1, x2
-
-        # restore input
-        yout = torch.cat([y1, y2], dim=1).contiguous()
-        with torch.no_grad():
-            y.storage().resize_(int(np.prod(yout.shape)))
-            y.set_(yout)
-
         return (grad_input, None, None) + FWgrads + GWgrads
 
 
 class AffineBlockFunction2(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, Fm, Gm, *weights):
+    def forward(ctx, xin, Fm, Gm, *weights):
         """Forward pass for the affine block computes:
         {x1, x2} = x
         {log_s1, t1} = Fm(x2)
@@ -405,7 +361,7 @@ class AffineBlockFunction2(torch.autograd.Function):
 
         """
         # check if possible to partition into two equally sized partitions
-        assert (x.shape[1] % 2 == 0)  # nosec
+        assert xin.shape[1] % 2 == 0  # nosec
 
         # store partition size, Fm and Gm functions in context
         ctx.Fm = Fm
@@ -413,6 +369,7 @@ class AffineBlockFunction2(torch.autograd.Function):
 
         with torch.no_grad():
             # partition in two equally sized set of channels
+            x = xin.detach()
             x1, x2 = torch.chunk(x, 2, dim=1)
             x1, x2 = x1.contiguous(), x2.contiguous()
 
@@ -428,14 +385,10 @@ class AffineBlockFunction2(torch.autograd.Function):
             y2 = x2 * gmr1 + gmr2
             x2.set_()
             del x2
-            output = torch.cat([y1, y2], dim=1)
-            y1.set_()
-            del y1
-            y2.set_()
-            del y2
+            output = torch.cat([y1, y2], dim=1).detach_()
 
         # save the input and output variables
-        ctx.save_for_backward(x.data, output)
+        ctx.save_for_backward(xin, output)
 
         return output
 
@@ -471,12 +424,6 @@ class AffineBlockFunction2(torch.autograd.Function):
             x1_stop = x1.detach()
             x1_stop.requires_grad = True
 
-            # restore input
-            xout = torch.cat([x1, x2], dim=1).contiguous()
-            with torch.no_grad():
-                x.storage().resize_(int(np.prod(xout.shape)))
-                x.set_(xout).detach()  # NOTE .detach() is very important here.
-
             # compute outputs building a sub-graph
             z1 = x1_stop * F_x21 + F_x22
             y2_ = x2_stop * G_z11 + G_z12
@@ -503,7 +450,7 @@ class AffineBlockFunction2(torch.autograd.Function):
 
 class AffineBlockInverseFunction2(torch.autograd.Function):
     @staticmethod
-    def forward(cty, y, Fm, Gm, *weights):
+    def forward(cty, yin, Fm, Gm, *weights):
         """Forward pass for the affine block computes:
 
         Parameters
@@ -526,7 +473,7 @@ class AffineBlockInverseFunction2(torch.autograd.Function):
 
         """
         # check if possible to partition into two equally sized partitions
-        assert (y.shape[1] % 2 == 0)  # nosec
+        assert yin.shape[1] % 2 == 0  # nosec
 
         # store partition size, Fm and Gm functions in context
         cty.Fm = Fm
@@ -534,6 +481,7 @@ class AffineBlockInverseFunction2(torch.autograd.Function):
 
         with torch.no_grad():
             # partition in two equally sized set of channels
+            y = yin.detach()
             y1, y2 = torch.chunk(y, 2, dim=1)
             y1, y2 = y1.contiguous(), y2.contiguous()
 
@@ -549,14 +497,10 @@ class AffineBlockInverseFunction2(torch.autograd.Function):
             x1 = (y1 - fmr2) / fmr1
             y1.set_()
             del y1
-            output = torch.cat([x1, x2], dim=1)
-            x1.set_()
-            del x1
-            x2.set_()
-            del x2
+            output = torch.cat([x1, x2], dim=1).detach_()
 
         # save the input and output variables
-        cty.save_for_backward(y.data, output)
+        cty.save_for_backward(yin, output)
 
         return output
 
@@ -592,12 +536,6 @@ class AffineBlockInverseFunction2(torch.autograd.Function):
             y2_stop = y2.detach()
             y2_stop.requires_grad = True
 
-            # restore input
-            yout = torch.cat([y1, y2], dim=1).contiguous()
-            with torch.no_grad():
-                y.storage().resize_(int(np.prod(yout.shape)))
-                y.set_(yout).detach()  # NOTE .detach() is very important here.
-
             # compute outputs building a sub-graph
             z1 = (y2_stop - G_y12) / G_y11
             x1_ = (y1_stop - F_z12) / F_z11
@@ -615,9 +553,5 @@ class AffineBlockInverseFunction2(torch.autograd.Function):
             y2_grad = dd[0]
 
             grad_input = torch.cat([y1_grad, y2_grad], dim=1)
-
-            x1_.detach_()
-            x2_.detach_()
-            del x1_, x2_
 
         return (grad_input, None, None) + FWgrads + GWgrads

--- a/memcnn/models/resnet.py
+++ b/memcnn/models/resnet.py
@@ -15,7 +15,7 @@ Author: Sil van de Leemput
 """
 import torch.nn as nn
 import math
-from memcnn.models.revop import ReversibleModule, create_coupling
+from memcnn.models.revop import InvertibleModuleWrapper, create_coupling
 
 __all__ = ['ResNet', 'BasicBlock', 'Bottleneck', 'RevBasicBlock', 'RevBottleneck', 'BasicBlockSub', 'BottleneckSub',
            'conv3x3', 'batch_norm']
@@ -76,7 +76,7 @@ class RevBasicBlock(nn.Module):
             gm = BasicBlockSub(inplanes // 2, planes // 2, stride, noactivation)
             fm = BasicBlockSub(inplanes // 2, planes // 2, stride, noactivation)
             coupling = create_coupling(Fm=fm, Gm=gm, coupling='additive')
-            self.revblock = ReversibleModule(fn=coupling, keep_input=False)
+            self.revblock = InvertibleModuleWrapper(fn=coupling, keep_input=False)
         else:
             self.basicblock_sub = BasicBlockSub(inplanes, planes, stride, noactivation)
         self.downsample = downsample
@@ -101,7 +101,7 @@ class RevBottleneck(nn.Module):
             gm = BottleneckSub(inplanes // 2, planes // 2, stride, noactivation)
             fm = BottleneckSub(inplanes // 2, planes // 2, stride, noactivation)
             coupling = create_coupling(Fm=fm, Gm=gm, coupling='additive')
-            self.revblock = ReversibleModule(fn=coupling, keep_input=False)
+            self.revblock = InvertibleModuleWrapper(fn=coupling, keep_input=False)
         else:
             self.bottleneck_sub = BottleneckSub(inplanes, planes, stride, noactivation)
         self.downsample = downsample
@@ -215,7 +215,7 @@ class ResNet(nn.Module):
     def configure(self):
         """Initialization specific configuration settings"""
         for m in self.modules():
-            if isinstance(m, ReversibleModule):
+            if isinstance(m, InvertibleModuleWrapper):
                 m.implementation = self.implementation
             elif isinstance(m, nn.BatchNorm2d):
                 if self.batch_norm_fix:

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -263,6 +263,8 @@ def is_invertible_module(module_in, test_input, atol=1e-6):
     with torch.no_grad():
         if not torch.allclose(module_in.inverse(module_in(test_input)), test_input, atol=atol):
             return False
+        if not torch.allclose(module_in(module_in.inverse(test_input)), test_input, atol=atol):
+            return False
         if test_input is module_in(test_input):
             return False
         if test_input is module_in.inverse(test_input):

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-
+from functools import partial
+import numpy as np
+import torch
 import torch.nn as nn
 import warnings
 from memcnn.models.additive import AdditiveBlock
@@ -10,9 +12,164 @@ from memcnn.models.utils import pytorch_version_one_and_above
 warnings.filterwarnings(action='ignore', category=UserWarning)
 
 
-class ReversibleBlock(nn.Module):
+def signal_hook(grad_output, rev_block, direction):
+    state = rev_block._bwd_state[direction] == 0
+    # print("SIGNAL {} {}".format(direction, state))
+    rev_block._bwd_state[direction] = 1 if state else 0
+
+
+def backward_hook(grad_output, keep_input, rev_block, compute_input_fn, compute_output_fn, direction, input_tensor, output_tensor):
+    # print("BW hook runs {} {} {} {} {} {}".format(direction, grad_output.shape, keep_input, None, compute_input_fn.__name__, compute_output_fn.__name__))
+    perform_action = rev_block._bwd_state[direction] == 0
+    # print("HOOK {} {} in:{} out:{}".format(direction, perform_action, input_tensor.storage().size(), output_tensor.storage().size()))
+    rev_block._bwd_state[direction] = 1 if perform_action else 0
+    if perform_action:
+        # restore input
+        if not keep_input:
+            with torch.no_grad():
+                input_inverted = compute_input_fn(output_tensor)
+                if pytorch_version_one_and_above:
+                    input_tensor.storage().resize_(int(np.prod(input_tensor.size())))
+                    input_tensor.set_(input_inverted)
+                else:
+                    input_tensor.set_(input_inverted)
+
+        # compute gradients
+        with torch.set_grad_enabled(True):
+            temp_output = compute_output_fn(input_tensor)
+            with torch.no_grad():
+                temp_output.set_(output_tensor)
+            temp_output.backward(gradient=grad_output)
+
+
+class ReversibleModule(nn.Module):
+    def __init__(self, fn, keep_input=False, keep_input_inverse=False, disable=False):
+        """The ReversibleModule
+
+        Parameters
+        ----------
+            fn : :obj:`torch.nn.Module`
+                A torch.nn.Module which has a forward and an inverse function implemented with
+                :math:`x == m.inverse(m.forward(x))`
+
+            keep_input : :obj:`bool`, optional
+                Set to retain the input information on forward, by default it can be discarded since it will be
+                reconstructed upon the backward pass.
+
+            keep_input_inverse : :obj:`bool`, optional
+                Set to retain the input information on inverse, by default it can be discarded since it will be
+                reconstructed upon the backward pass.
+
+            disable : :obj:`bool`, optional
+                This will disable the detached graph approach with the backward hook.
+                Essentially this renders the function as `y = fn(x)` without any of the memory savings.
+                Setting this to true will also ignore the keep_input and keep_input_inverse properties.
+
+        Attributes
+        ----------
+            keep_input : :obj:`bool`, optional
+                Set to retain the input information on forward, by default it can be discarded since it will be
+                reconstructed upon the backward pass.
+
+            keep_input_inverse : :obj:`bool`, optional
+                Set to retain the input information on inverse, by default it can be discarded since it will be
+                reconstructed upon the backward pass.
+
+        Raises
+        ------
+        NotImplementedError
+            If an unknown coupling or implementation is given.
+
+        """
+        super(ReversibleModule, self).__init__()
+        self.disable = disable
+        self.keep_input = keep_input
+        self.keep_input_inverse = keep_input_inverse
+        self._fn = fn
+        self._bwd_state = {"forward":0, "inverse":0}
+
+
+    def forward(self, xin):
+        """Forward operation :math:`R(x) = y`
+
+        Parameters
+        ----------
+            xin : :obj:`torch.Tensor`
+                Input torch tensor.
+
+        Returns
+        -------
+            :obj:`torch.Tensor`
+                Output torch tensor y.
+
+        """
+        if not self.disable:
+            x = xin.detach()  # Makes a detached copy which shares the storage
+            y = self._fn(x)
+            input_tensor = xin
+            output_tensor = y
+            # clears the referenced storage data linked to the input tensor as it can be reversed on the backward pass
+            if not self.keep_input:
+                if not pytorch_version_one_and_above:
+                    # PyTorch 0.4 way to clear storage
+                    input_tensor.data.set_()
+                else:
+                    # PyTorch 1.0+ way to clear storage
+                    input_tensor.storage().resize_(0)
+            if self.training:
+                xin.register_hook(hook=partial(signal_hook, rev_block=self, direction="forward"))
+                y.register_hook(hook=partial(backward_hook, keep_input=self.keep_input, rev_block=self,
+                                             compute_input_fn=self._fn.inverse, compute_output_fn=self._fn.forward,
+                                             direction="forward", input_tensor=input_tensor, output_tensor=output_tensor))
+
+            y.detach_()  # Detaches y in-place (inbetween computations can now be discarded)
+            y.requires_grad = self.training
+        else:
+            y = self._fn(xin)
+        return y
+
+    def inverse(self, yin):
+        """Inverse operation :math:`R^{-1}(y) = x`
+
+        Parameters
+        ----------
+            yin : :obj:`torch.Tensor`
+                Input torch tensor.
+
+        Returns
+        -------
+            :obj:`torch.Tensor`
+                Output torch tensor x.
+
+        """
+        if not self.disable:
+            y = yin.detach()  # Makes a detached copy which shares the storage
+            x = self._fn.inverse(y)
+            input_tensor = yin
+            output_tensor = x
+            # clears the referenced storage data linked to the input tensor as it can be reversed on the backward pass
+            if not self.keep_input_inverse:
+                if not pytorch_version_one_and_above:
+                    # PyTorch 0.4 way to clear storage
+                    input_tensor.data.set_()
+                else:
+                    # PyTorch 1.0+ way to clear storage
+                    input_tensor.storage().resize_(0)
+            if self.training:
+                yin.register_hook(hook=partial(signal_hook, rev_block=self, direction="inverse"))
+                x.register_hook(hook=partial(backward_hook, keep_input=self.keep_input_inverse, rev_block=self,
+                                             compute_input_fn=self._fn.forward, compute_output_fn=self._fn.inverse,
+                                             direction="inverse", input_tensor=input_tensor, output_tensor=output_tensor))
+            x.detach_()  # Detaches x in-place (inbetween computations can now be discarded)
+            x.requires_grad = self.training
+        else:
+            x = self._fn.inverse(yin)
+        return x
+
+
+class ReversibleBlock(ReversibleModule):
     def __init__(self, Fm, Gm=None, coupling='additive', keep_input=False, keep_input_inverse=False,
-                 implementation_fwd=1, implementation_bwd=1, adapter=None):
+                 implementation_fwd=-1, implementation_bwd=-1, adapter=None):
         """The ReversibleBlock
 
         Note
@@ -75,66 +232,13 @@ class ReversibleBlock(nn.Module):
             If an unknown coupling or implementation is given.
 
         """
-        super(ReversibleBlock, self).__init__()
-        self.keep_input = keep_input
-        self.keep_input_inverse = keep_input_inverse
+        warnings.warn("This class has been deprecated. Use the more flexible ReversibleModule class", DeprecationWarning)
         if coupling == 'additive':
-            self.rev_block = AdditiveBlock(Fm, Gm,
-                                           implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
+            fn = AdditiveBlock(Fm, Gm,
+                               implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
         elif coupling == 'affine':
-            self.rev_block = AffineBlock(Fm, Gm, adapter=adapter,
-                                         implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
+            fn = AffineBlock(Fm, Gm, adapter=adapter,
+                             implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
         else:
             raise NotImplementedError('Unknown coupling method: %s' % coupling)
-
-    def forward(self, x):
-        """Forward operation :math:`R(x) = y`
-
-        Parameters
-        ----------
-            x : :obj:`torch.Tensor`
-                Input torch tensor.
-
-        Returns
-        -------
-            :obj:`torch.Tensor`
-                Output torch tensor y.
-
-        """
-        y = self.rev_block(x)
-        # clears the referenced storage data linked to the input tensor as it can be reversed on the backward pass
-        if not self.keep_input:
-            if not pytorch_version_one_and_above:
-                # PyTorch 0.4 way to clear storage
-                x.data.set_()
-            else:
-                # PyTorch 1.0+ way to clear storage
-                x.storage().resize_(0)
-
-        return y
-
-    def inverse(self, y):
-        """Inverse operation :math:`R^{-1}(y) = x`
-
-        Parameters
-        ----------
-            y : :obj:`torch.Tensor`
-                Input torch tensor.
-
-        Returns
-        -------
-            :obj:`torch.Tensor`
-                Output torch tensor x.
-
-        """
-        x = self.rev_block.inverse(y)
-        # clears the referenced storage data linked to the input tensor as it can be reversed on the backward pass
-        if not self.keep_input_inverse:
-            if not pytorch_version_one_and_above:
-                # PyTorch 0.4 way to clear storage
-                y.data.set_()
-            else:
-                # PyTorch 1.0+ way to clear storage
-                y.storage().resize_(0)
-
-        return x
+        super(ReversibleBlock, self).__init__(fn, keep_input=keep_input, keep_input_inverse=keep_input_inverse)

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -35,8 +35,6 @@ def backward_hook(grad_output, keep_input, compute_input_fn, compute_output_fn,
         # compute gradients
         with torch.set_grad_enabled(True):
             temp_output = compute_output_fn(input_tensor)
-            with torch.no_grad():
-                temp_output.set_(output_tensor)
             temp_output.backward(gradient=grad_output)
 
 

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -4,8 +4,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 import warnings
-from memcnn.models.additive import AdditiveBlock
-from memcnn.models.affine import AffineBlock
+from memcnn.models.additive import AdditiveCoupling
+from memcnn.models.affine import AffineCoupling
 from memcnn.models.utils import pytorch_version_one_and_above
 
 
@@ -246,11 +246,11 @@ class ReversibleBlock(ReversibleModule):
 
 def create_coupling(Fm, Gm=None, coupling='additive', implementation_fwd=-1, implementation_bwd=-1, adapter=None):
     if coupling == 'additive':
-        fn = AdditiveBlock(Fm, Gm,
-                           implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
+        fn = AdditiveCoupling(Fm, Gm,
+                              implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
     elif coupling == 'affine':
-        fn = AffineBlock(Fm, Gm, adapter=adapter,
-                         implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
+        fn = AffineCoupling(Fm, Gm, adapter=adapter,
+                            implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd)
     else:
         raise NotImplementedError('Unknown coupling method: %s' % coupling)
     return fn

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -261,4 +261,10 @@ def is_invertible_module(module_in, test_input, atol=1e-6):
     if not hasattr(module_in, "inverse"):
         return False
     with torch.no_grad():
-        return torch.allclose(module_in.inverse(module_in(test_input)), test_input, atol=atol)
+        if not torch.allclose(module_in.inverse(module_in(test_input)), test_input, atol=atol):
+            return False
+        if test_input is module_in(test_input):
+            return False
+        if test_input is module_in.inverse(test_input):
+            return False
+    return True

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -12,13 +12,13 @@ from memcnn.models.utils import pytorch_version_one_and_above
 warnings.filterwarnings(action='ignore', category=UserWarning)
 
 
-def signal_hook(grad_output, valid_states, state_index):
+def signal_hook(grad_output, valid_states, state_index):  # pragma: no cover
     state = valid_states[state_index]
     valid_states[state_index] = not state
 
 
 def backward_hook(grad_output, keep_input, compute_input_fn, compute_output_fn,
-                  input_tensor, output_tensor, valid_states, state_index):
+                  input_tensor, output_tensor, valid_states, state_index):  # pragma: no cover
     perform_action = valid_states[state_index]
     valid_states[state_index] = not perform_action
     if perform_action:

--- a/memcnn/models/tests/test_couplings.py
+++ b/memcnn/models/tests/test_couplings.py
@@ -1,0 +1,108 @@
+import torch
+import torch.nn
+import pytest
+import copy
+import warnings
+
+from memcnn import create_coupling, ReversibleModule
+from memcnn.models.tests.test_revop import set_seeds
+from memcnn.models.affine import AffineAdapterNaive
+
+
+@pytest.mark.parametrize('coupling', ['additive', 'affine'])
+@pytest.mark.parametrize('bwd', [False, True])
+@pytest.mark.parametrize('implementation', [-1, 0, 1])
+def test_coupling_implementations_against_reference(coupling, bwd, implementation):
+    """Test if similar gradients and weights results are obtained after similar training for the couplings
+
+    * test training the block for a single step and compare weights and grads for implementations: 0, 1
+    * test against normal non Reversible Block function
+    * test if recreated input and produced output are contiguous
+
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter(action='ignore', category=DeprecationWarning)
+        for seed in range(10):
+            set_seeds(seed)
+
+            X = torch.rand(2, 4, 5, 5)
+
+            # define models and their copies
+            c1 = torch.nn.Conv2d(2, 2, 3, padding=1)
+            c2 = torch.nn.Conv2d(2, 2, 3, padding=1)
+            c1_2 = copy.deepcopy(c1)
+            c2_2 = copy.deepcopy(c2)
+
+            # are weights between models the same, but do they differ between convolutions?
+            assert torch.equal(c1.weight, c1_2.weight)
+            assert torch.equal(c2.weight, c2_2.weight)
+            assert torch.equal(c1.bias, c1_2.bias)
+            assert torch.equal(c2.bias, c2_2.bias)
+            assert not torch.equal(c1.weight, c2.weight)
+
+            # define optimizers
+            optim1 = torch.optim.SGD([e for e in c1.parameters()] + [e for e in c2.parameters()], 0.1)
+            optim2 = torch.optim.SGD([e for e in c1_2.parameters()] + [e for e in c2_2.parameters()], 0.1)
+            for e in [c1, c2, c1_2, c2_2]:
+                e.train()
+
+            # define an arbitrary reversible function and define graph for model 1
+            XX = X.detach().clone().requires_grad_()
+            coupling_fn = create_coupling(Fm=c1, Gm=c2, coupling=coupling, implementation_fwd=-1,
+                                          implementation_bwd=-1, adapter=AffineAdapterNaive)
+            Y = coupling_fn.inverse(XX) if bwd else coupling_fn.forward(XX)
+            loss = torch.mean(Y)
+
+            # define the reversible function without custom backprop and define graph for model 2
+            XX2 = X.detach().clone().requires_grad_()
+            coupling_fn2 = create_coupling(Fm=c1_2, Gm=c2_2, coupling=coupling, implementation_fwd=implementation,
+                                           implementation_bwd=implementation, adapter=AffineAdapterNaive)
+            Y2 = coupling_fn2.inverse(XX2) if bwd else coupling_fn2.forward(XX2)
+            loss2 = torch.mean(Y2)
+
+            # compute gradients manually
+            grads = torch.autograd.grad(loss2, (XX2, c1_2.weight, c2_2.weight, c1_2.bias, c2_2.bias), None, retain_graph=True)
+
+            # compute gradients using backward and perform optimization model 2
+            loss2.backward()
+            optim2.step()
+
+            # gradients computed manually match those of the .backward() pass
+            assert torch.equal(c1_2.weight.grad, grads[1])
+            assert torch.equal(c2_2.weight.grad, grads[2])
+            assert torch.equal(c1_2.bias.grad, grads[3])
+            assert torch.equal(c2_2.bias.grad, grads[4])
+
+            # weights differ after training a single model?
+            assert not torch.equal(c1.weight, c1_2.weight)
+            assert not torch.equal(c2.weight, c2_2.weight)
+            assert not torch.equal(c1.bias, c1_2.bias)
+            assert not torch.equal(c2.bias, c2_2.bias)
+
+            # compute gradients and perform optimization model 1
+            loss.backward()
+            optim1.step()
+
+            # weights are approximately the same after training both models?
+            assert torch.allclose(c1.weight.detach(), c1_2.weight.detach())
+            assert torch.allclose(c2.weight.detach(), c2_2.weight.detach())
+            assert torch.allclose(c1.bias.detach(), c1_2.bias.detach())
+            assert torch.allclose(c2.bias.detach(), c2_2.bias.detach())
+
+            # gradients are approximately the same after training both models?
+            assert torch.allclose(c1.weight.grad.detach(), c1_2.weight.grad.detach())
+            assert torch.allclose(c2.weight.grad.detach(), c2_2.weight.grad.detach())
+            assert torch.allclose(c1.bias.grad.detach(), c1_2.bias.grad.detach())
+            assert torch.allclose(c2.bias.grad.detach(), c2_2.bias.grad.detach())
+
+            fn = ReversibleModule(fn=coupling_fn, keep_input=False, keep_input_inverse=False)
+            Yout = fn.inverse(XX) if bwd else fn.forward(XX)
+            loss = torch.mean(Yout)
+            loss.backward()
+            assert XX.storage().size() > 0
+
+            fn2 = ReversibleModule(fn=coupling_fn2, keep_input=False, keep_input_inverse=False)
+            Yout2 = fn2.inverse(XX2) if bwd else fn2.forward(XX2)
+            loss = torch.mean(Yout2)
+            loss.backward()
+            assert XX2.storage().size() > 0

--- a/memcnn/models/tests/test_couplings.py
+++ b/memcnn/models/tests/test_couplings.py
@@ -5,8 +5,9 @@ import copy
 import warnings
 
 from memcnn import create_coupling, ReversibleModule
-from memcnn.models.tests.test_revop import set_seeds
-from memcnn.models.affine import AffineAdapterNaive
+from memcnn.models.tests.test_revop import set_seeds, SubModule
+from memcnn.models.affine import AffineAdapterNaive, AffineBlock
+from memcnn.models.additive import AdditiveBlock
 
 
 @pytest.mark.parametrize('coupling', ['additive', 'affine'])
@@ -106,3 +107,15 @@ def test_coupling_implementations_against_reference(coupling, bwd, implementatio
             loss = torch.mean(Yout2)
             loss.backward()
             assert XX2.storage().size() > 0
+
+
+def test_legacy_additive_coupling():
+    with warnings.catch_warnings():
+        warnings.simplefilter(action='ignore', category=DeprecationWarning)
+        AdditiveBlock(Fm=SubModule())
+
+
+def test_legacy_affine_coupling():
+    with warnings.catch_warnings():
+        warnings.simplefilter(action='ignore', category=DeprecationWarning)
+        AffineBlock(Fm=SubModule())

--- a/memcnn/models/tests/test_memory_saving.py
+++ b/memcnn/models/tests/test_memory_saving.py
@@ -194,8 +194,8 @@ class MemReporter(object):
 @pytest.mark.parametrize('coupling', ['additive', 'affine'])
 @pytest.mark.parametrize('keep_input', [True, False])
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])
-def test_memory_saving(device, coupling, keep_input):
-    """Test memory saving of the reversible block
+def test_memory_saving_invertible_model_wrapper(device, coupling, keep_input):
+    """Test memory saving of the invertible model wrapper
 
     * tests fitting a large number of images by creating a deep network requiring large
       intermediate feature maps for training

--- a/memcnn/models/tests/test_memory_saving.py
+++ b/memcnn/models/tests/test_memory_saving.py
@@ -226,7 +226,7 @@ def test_memory_saving(device, coupling, keep_input):
     with torch.set_grad_enabled(True):
         dims = [2, 10, 10, 10]
         depth = 5
-        memuse = float(np.prod(dims + [depth, 4, ])) / float(1024 ** 2)
+
         xx = torch.rand(*dims, device=device, dtype=torch.float32).requires_grad_()
         ytarget = torch.rand(*dims, device=device, dtype=torch.float32)
 
@@ -255,10 +255,13 @@ def test_memory_saving(device, coupling, keep_input):
         gc.enable()
 
         if device == 'cpu':
-            memuse = 0.02
-
-        if keep_input:
-            assert mem_after_forward - mem_start >= memuse
+            memuse = 0.05
         else:
-            assert mem_after_forward - mem_start < (1 if device == 'cuda' else memuse)
+            memuse = float(np.prod(dims + [depth, 4, ])) / float(1024 ** 2)
+
+        measured_memuse = mem_after_forward - mem_start
+        if keep_input:
+            assert measured_memuse >= memuse
+        else:
+            assert measured_memuse < (1 if device == 'cuda' else memuse)
         # assert math.floor(mem_after_backward - mem_start) >= 9

--- a/memcnn/models/tests/test_revop.py
+++ b/memcnn/models/tests/test_revop.py
@@ -304,6 +304,9 @@ def test_chained_reversible_module_multiple_forward_and_inverse_train_passes():
                 Xinv2 = rb(Y)
                 Xinv3 = rb(Y)
 
+            for item in [Xinv, Xinv2, Xinv3]:
+                assert torch.allclose(X, item, atol=1e-04)
+
             loss = torch.nn.MSELoss()(Xinv, Ytarget)
             assert not torch.isnan(loss)
 
@@ -481,13 +484,13 @@ def test_normal_vs_reversible_module(coupling):
         assert Y.is_contiguous()
 
         # weights are approximately the same after training both models?
-        assert np.allclose(c1.weight.data.numpy(), c1_2.weight.data.numpy()) #, atol=1e-06)
+        assert np.allclose(c1.weight.data.numpy(), c1_2.weight.data.numpy())
         assert np.allclose(c2.weight.data.numpy(), c2_2.weight.data.numpy())
         assert np.allclose(c1.bias.data.numpy(), c1_2.bias.data.numpy())
         assert np.allclose(c2.bias.data.numpy(), c2_2.bias.data.numpy())
 
         # gradients are approximately the same after training both models?
-        assert np.allclose(c1.weight.grad.data.numpy(), c1_2.weight.grad.data.numpy()) #, atol=1e-06)
+        assert np.allclose(c1.weight.grad.data.numpy(), c1_2.weight.grad.data.numpy())
         assert np.allclose(c2.weight.grad.data.numpy(), c2_2.weight.grad.data.numpy())
         assert np.allclose(c1.bias.grad.data.numpy(), c1_2.bias.grad.data.numpy())
         assert np.allclose(c2.bias.grad.data.numpy(), c2_2.bias.grad.data.numpy())

--- a/memcnn/models/tests/test_revop.py
+++ b/memcnn/models/tests/test_revop.py
@@ -225,7 +225,6 @@ def test_chained_reversible_module_multiple_forward_and_inverse_train_passes():
     optim = torch.optim.SGD(rb_temp.parameters(), lr=0.01)
 
     initial_params = [p.detach().clone() for p in rb_temp.parameters()]
-    initial_buffers = [b.detach().clone() for b in rb_temp.buffers()]
     initial_state = copy.deepcopy(rb_temp.state_dict())
     initial_optim_state = copy.deepcopy(optim.state_dict())
 
@@ -246,8 +245,6 @@ def test_chained_reversible_module_multiple_forward_and_inverse_train_passes():
         with torch.no_grad():
             for (name, p), p_initial in zip(rb.named_parameters(), initial_params):
                 p.set_(p_initial)
-            for (name, b), b_initial in zip(rb.named_buffers(), initial_buffers):
-                b.set_(b_initial)
 
         rb.load_state_dict(initial_state)
         optim = torch.optim.SGD(rb_temp.parameters(), lr=0.01)

--- a/memcnn/models/tests/test_revop.py
+++ b/memcnn/models/tests/test_revop.py
@@ -5,10 +5,10 @@ import torch
 import torch.nn
 import numpy as np
 import copy
-from memcnn.models.affine import AffineAdapterNaive, AffineAdapterSigmoid, AffineBlock
+from memcnn.models.affine import AffineAdapterNaive, AffineAdapterSigmoid, AffineCoupling
 from memcnn import ReversibleBlock
 from memcnn.models.revop import ReversibleModule, create_coupling, is_invertible_module
-from memcnn.models.additive import AdditiveBlock
+from memcnn.models.additive import AdditiveCoupling
 
 
 def set_seeds(seed):
@@ -60,7 +60,7 @@ def is_memory_cleared(var, isclear, shape):
 def test_is_invertible_module():
     X = torch.zeros(1, 10, 10, 10)
     assert not is_invertible_module(torch.nn.Conv2d(10, 10, kernel_size=(1, 1)), X)
-    fn = AdditiveBlock(SubModule(),implementation_bwd=-1, implementation_fwd=-1)
+    fn = AdditiveCoupling(SubModule(), implementation_bwd=-1, implementation_fwd=-1)
     assert is_invertible_module(fn, X)
     class FakeInverse(torch.nn.Module):
         def forward(self, x):
@@ -146,9 +146,9 @@ def test_input_output_invertible_function_share_tensor():
 
 
 @pytest.mark.parametrize('fn', [
-    AdditiveBlock(Fm=SubModule(), implementation_fwd=-1, implementation_bwd=-1),
-    AffineBlock(Fm=SubModule(), implementation_fwd=-1, implementation_bwd=-1, adapter=AffineAdapterNaive),
-    AffineBlock(Fm=SubModule(out_filters=10), implementation_fwd=-1, implementation_bwd=-1, adapter=AffineAdapterSigmoid),
+    AdditiveCoupling(Fm=SubModule(), implementation_fwd=-1, implementation_bwd=-1),
+    AffineCoupling(Fm=SubModule(), implementation_fwd=-1, implementation_bwd=-1, adapter=AffineAdapterNaive),
+    AffineCoupling(Fm=SubModule(out_filters=10), implementation_fwd=-1, implementation_bwd=-1, adapter=AffineAdapterSigmoid),
     MultiplicationInverse()
 ])
 @pytest.mark.parametrize('bwd', [False, True])

--- a/memcnn/trainers/classification.py
+++ b/memcnn/trainers/classification.py
@@ -102,10 +102,13 @@ def train(manager,
 
         score = model(vx)
         loss = ceriterion(score, vl)
+
         if use_cuda:
             activation_mem_allocation = torch.cuda.memory_allocated(device) - model_mem_allocation
             act_mem_activations.update(activation_mem_allocation, iteration)
-            # logger.info('Activations memory allocation: {}'.format(activation_mem_allocation))
+
+        if torch.isnan(loss):
+            raise ValueError("Loss became NaN during iteration {}".format(iteration))
 
         optimizer.zero_grad()
         loss.backward()

--- a/memcnn/trainers/tests/resources/experiments.json
+++ b/memcnn/trainers/tests/resources/experiments.json
@@ -115,10 +115,10 @@
         }
     },
 
-    "epoch1":
+    "epoch5":
     {
         "data_loader_params": {
-            "max_epoch": 1
+            "max_epoch": 5
         }
     }
 }

--- a/memcnn/trainers/tests/test_classification.py
+++ b/memcnn/trainers/tests/test_classification.py
@@ -1,3 +1,5 @@
+import pytest
+
 from memcnn.trainers.classification import train
 from memcnn.experiment.manager import ExperimentManager
 from memcnn.data.cifar import get_cifar_data_loaders
@@ -6,22 +8,23 @@ import torch
 from torchvision.datasets.cifar import CIFAR10
 
 
+class SimpleTestingModel(torch.nn.Module):
+    def __init__(self, klasses):
+        super(SimpleTestingModel, self).__init__()
+        self.conv = torch.nn.Conv2d(3, klasses, 1)
+        self.avgpool = torch.nn.AvgPool2d(32)
+        self.klasses = klasses
+
+    def forward(self, x):
+        return self.avgpool(self.conv(x)).reshape(x.shape[0], self.klasses)
+
+
 def test_train(tmp_path):
     expdir = str(tmp_path / "testexp")
     tmp_data_dir = str(tmp_path / "tmpdata")
     num_klasses = 10
 
-    class TestModel(torch.nn.Module):
-        def __init__(self, klasses):
-            super(TestModel, self).__init__()
-            self.conv = torch.nn.Conv2d(3, klasses, 1)
-            self.avgpool = torch.nn.AvgPool2d(32)
-            self.klasses = klasses
-
-        def forward(self, x):
-            return self.avgpool(self.conv(x)).reshape(x.shape[0], self.klasses)
-
-    model = TestModel(num_klasses)
+    model = SimpleTestingModel(num_klasses)
     optimizer = torch.optim.SGD(params=model.parameters(), lr=0.01)
     manager = ExperimentManager(expdir, model, optimizer)
     manager.make_dirs()
@@ -38,3 +41,36 @@ def test_train(tmp_path):
           valid_iter=1,
           use_cuda=False,
           loss=loss)
+
+
+def test_train_with_nan_loss(tmp_path):
+    class NanLoss(torch.nn.Module):
+        def __init__(self):
+            super(NanLoss, self).__init__()
+
+        def forward(self, Ypred, Y, W=None):
+            return Ypred.mean() * float('nan')
+
+    expdir = str(tmp_path / "testexp")
+    tmp_data_dir = str(tmp_path / "tmpdata")
+    num_klasses = 10
+
+    model = SimpleTestingModel(num_klasses)
+    optimizer = torch.optim.SGD(params=model.parameters(), lr=0.01)
+    manager = ExperimentManager(expdir, model, optimizer)
+    manager.make_dirs()
+
+    train_loader, test_loader = get_cifar_data_loaders(CIFAR10, tmp_data_dir, 40000, 2, 0)
+    loss = NanLoss()
+
+    with pytest.raises(ValueError) as e:
+        train(manager,
+              train_loader,
+              test_loader,
+              start_iter=1,
+              disp_iter=1,
+              save_iter=1,
+              valid_iter=1,
+              use_cuda=False,
+              loss=loss)
+    assert "Loss became NaN during iteration" in str(e.value)

--- a/memcnn/trainers/tests/test_train.py
+++ b/memcnn/trainers/tests/test_train.py
@@ -1,7 +1,11 @@
+import json
+
 import pytest
 import os
 import sys
 import torch
+
+from memcnn.experiment.manager import ExperimentManager
 from memcnn.train import run_experiment, main
 try:
     from pathlib2 import Path
@@ -63,19 +67,20 @@ def test_run_experiment(tmp_path):
 
 
 @pytest.mark.parametrize("network", [
-    pytest.param('resnet32', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
-    pytest.param('resnet110', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
-    pytest.param('resnet164', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
-    pytest.param('revnet38', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
-    pytest.param('revnet110', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
-    pytest.param('revnet164', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI"))
+    pytest.param(network,
+                 marks=pytest.mark.skipif(
+                     condition=("FULL_NETWORK_TESTS" not in os.environ) and 'revnet38' != network,
+                     reason="Too memory intensive for CI so these are disabled by default. "
+                            "Set FULL_NETWORK_TESTS environment variable to enable the tests.")
+                 )
+    for network in ['resnet32', 'resnet110', 'resnet164', 'revnet38', 'revnet110', 'revnet164']
 ])
 @pytest.mark.parametrize("use_cuda", [
     False,
     pytest.param(True, marks=pytest.mark.skipif(condition=not torch.cuda.is_available(), reason="No GPU available"))
 ])
 def test_train_networks(tmp_path, network, use_cuda):
-    exptags = ['cifar10', network, 'epoch1']
+    exptags = ['cifar10', network, 'epoch5']
     exp_file = str(Path(__file__).parent / "resources" / "experiments.json")
     data_dir = str(tmp_path / "tmpdata")
     results_dir = str(tmp_path / "resdir")
@@ -84,5 +89,14 @@ def test_train_networks(tmp_path, network, use_cuda):
     run_experiment(experiment_tags=exptags, data_dir=data_dir, results_dir=results_dir,
                    start_fresh=True, use_cuda=use_cuda, workers=None, experiments_file=exp_file,
                    disp_iter=1,
-                   save_iter=1,
-                   valid_iter=1,)
+                   save_iter=5,
+                   valid_iter=5,)
+    experiment_dir = os.path.join(results_dir, '_'.join(exptags))
+    assert os.path.exists(experiment_dir)
+    manager = ExperimentManager(experiment_dir)
+    scalars_file = os.path.join(manager.log_dir, "scalars.json")
+    assert os.path.exists(scalars_file)
+    with open(scalars_file, "r") as f:
+        results = json.load(f)
+    # no results should hold any NaN values
+    assert not any([val != val for t, i, val in results["train_loss"]])

--- a/memcnn/trainers/tests/test_train.py
+++ b/memcnn/trainers/tests/test_train.py
@@ -62,15 +62,27 @@ def test_run_experiment(tmp_path):
     run_experiment(**run_params)
 
 
-def test_train_revnet164_with_memory_saving(tmp_path):
-    exptags = ['cifar10', 'revnet164', 'epoch1']
+@pytest.mark.parametrize("network", [
+    'resnet32',
+     pytest.param('resnet110', marks=pytest.mark.skipif(condition="CIRCLECI" in os.environ, reason="Too memory intensive for CI")),
+     pytest.param('resnet164', marks=pytest.mark.skipif(condition="CIRCLECI" in os.environ, reason="Too memory intensive for CI")),
+    'revnet38',
+    'revnet110',
+     pytest.param('revnet164', marks=pytest.mark.skipif(condition="CIRCLECI" in os.environ, reason="Too memory intensive for CI"))
+])
+@pytest.mark.parametrize("use_cuda", [
+    False,
+    pytest.param(True, marks=pytest.mark.skipif(condition=not torch.cuda.is_available(), reason="No GPU available"))
+])
+def test_train_networks(tmp_path, network, use_cuda):
+    exptags = ['cifar10', network, 'epoch1']
     exp_file = str(Path(__file__).parent / "resources" / "experiments.json")
     data_dir = str(tmp_path / "tmpdata")
     results_dir = str(tmp_path / "resdir")
     os.makedirs(data_dir)
     os.makedirs(results_dir)
     run_experiment(experiment_tags=exptags, data_dir=data_dir, results_dir=results_dir,
-                   start_fresh=True, use_cuda=False, workers=None, experiments_file=exp_file,
+                   start_fresh=True, use_cuda=use_cuda, workers=None, experiments_file=exp_file,
                    disp_iter=1,
                    save_iter=1,
                    valid_iter=1,)

--- a/memcnn/trainers/tests/test_train.py
+++ b/memcnn/trainers/tests/test_train.py
@@ -70,4 +70,7 @@ def test_train_revnet164_with_memory_saving(tmp_path):
     os.makedirs(data_dir)
     os.makedirs(results_dir)
     run_experiment(experiment_tags=exptags, data_dir=data_dir, results_dir=results_dir,
-                   start_fresh=True, use_cuda=False, workers=None, experiments_file=exp_file)
+                   start_fresh=True, use_cuda=False, workers=None, experiments_file=exp_file,
+                   disp_iter=1,
+                   save_iter=1,
+                   valid_iter=1,)

--- a/memcnn/trainers/tests/test_train.py
+++ b/memcnn/trainers/tests/test_train.py
@@ -63,12 +63,12 @@ def test_run_experiment(tmp_path):
 
 
 @pytest.mark.parametrize("network", [
-    'resnet32',
-     pytest.param('resnet110', marks=pytest.mark.skipif(condition="CIRCLECI" in os.environ, reason="Too memory intensive for CI")),
-     pytest.param('resnet164', marks=pytest.mark.skipif(condition="CIRCLECI" in os.environ, reason="Too memory intensive for CI")),
-    'revnet38',
-    'revnet110',
-     pytest.param('revnet164', marks=pytest.mark.skipif(condition="CIRCLECI" in os.environ, reason="Too memory intensive for CI"))
+    pytest.param('resnet32', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
+    pytest.param('resnet110', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
+    pytest.param('resnet164', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
+    pytest.param('revnet38', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
+    pytest.param('revnet110', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
+    pytest.param('revnet164', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
 ])
 @pytest.mark.parametrize("use_cuda", [
     False,

--- a/memcnn/trainers/tests/test_train.py
+++ b/memcnn/trainers/tests/test_train.py
@@ -63,12 +63,12 @@ def test_run_experiment(tmp_path):
 
 
 @pytest.mark.parametrize("network", [
-    pytest.param('resnet32', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
-    pytest.param('resnet110', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
-    pytest.param('resnet164', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
-    pytest.param('revnet38', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
-    pytest.param('revnet110', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
-    pytest.param('revnet164', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
+    pytest.param('resnet32', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
+    pytest.param('resnet110', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
+    pytest.param('resnet164', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
+    pytest.param('revnet38', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
+    pytest.param('revnet110', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI")),
+    pytest.param('revnet164', marks=pytest.mark.skipif(condition=True, reason="Too memory intensive for CI"))
 ])
 @pytest.mark.parametrize("use_cuda", [
     False,

--- a/memcnn/trainers/tests/test_train.py
+++ b/memcnn/trainers/tests/test_train.py
@@ -63,11 +63,11 @@ def test_run_experiment(tmp_path):
 
 
 @pytest.mark.parametrize("network", [
-    pytest.param('resnet32', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
+    pytest.param('resnet32', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
     pytest.param('resnet110', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
     pytest.param('resnet164', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
-    pytest.param('revnet38', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
-    pytest.param('revnet110', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
+    pytest.param('revnet38', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
+    pytest.param('revnet110', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI")),
     pytest.param('revnet164', marks=pytest.mark.skipif(condition="CIRCLE_JOB" in os.environ, reason="Too memory intensive for CI"))
 ])
 @pytest.mark.parametrize("use_cuda", [

--- a/memcnn/trainers/tests/test_train.py
+++ b/memcnn/trainers/tests/test_train.py
@@ -69,18 +69,18 @@ def test_run_experiment(tmp_path):
 @pytest.mark.parametrize("network", [
     pytest.param(network,
                  marks=pytest.mark.skipif(
-                     condition=("FULL_NETWORK_TESTS" not in os.environ) and 'revnet38' != network,
-                     reason="Too memory intensive for CI so these are disabled by default. "
+                     condition=("FULL_NETWORK_TESTS" not in os.environ) and ("revnet38" != network),
+                     reason="Too memory intensive for CI so these tests are disabled by default. "
                             "Set FULL_NETWORK_TESTS environment variable to enable the tests.")
                  )
-    for network in ['resnet32', 'resnet110', 'resnet164', 'revnet38', 'revnet110', 'revnet164']
+    for network in ["resnet32", "resnet110", "resnet164", "revnet38", "revnet110", "revnet164"]
 ])
 @pytest.mark.parametrize("use_cuda", [
     False,
     pytest.param(True, marks=pytest.mark.skipif(condition=not torch.cuda.is_available(), reason="No GPU available"))
 ])
 def test_train_networks(tmp_path, network, use_cuda):
-    exptags = ['cifar10', network, 'epoch5']
+    exptags = ["cifar10", network, "epoch5"]
     exp_file = str(Path(__file__).parent / "resources" / "experiments.json")
     data_dir = str(tmp_path / "tmpdata")
     results_dir = str(tmp_path / "resdir")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.1.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.install import install
 from setuptools import find_packages
 
 # circleci.py version
-VERSION = '1.0.1'
+VERSION = '1.1.0'
 
 with open('README.rst', 'r') as fh:
     long_description = fh.read().split('Results\n-------')[0]


### PR DESCRIPTION
This PR fixes #29 

* A complete refactor of MemCNN with changes to the API
  * Factored out the code responsible for the memory savings in a separate InvertibleModuleWrapper and reimplemented it using hooks
  * The InvertibleModuleWrapper allows for arbitrary invertible functions now (not just the additive and affine couplings)
  * The AdditiveBlock and AffineBlock have been refactored to AdditiveCoupling and AffineCoupling
  * The ReveribleBlock is now deprecated
  * The documentation and examples have been updated for the new API changes