### PR TITLE
Multi inputs and outputs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+1.3.2 (2020-03-05)
+------------------
+* Improved InvertibleModuleWrapper
+  * Added support for multi input/output invertible operations! Big thanks to Christian Etmann for the PR.
+* Improved the is_invertible_module test
+  * Added multi input/output checks
+  * Fixed random seed per default
+  * Additional warning checks have been added
+
 1.3.1 (2020-03-02)
 ------------------
 * HOTFIX InvertibleCheckpointFunction uses ref_count for inputs as well to avoid memory spikes

--- a/memcnn/__init__.py
+++ b/memcnn/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Sil van de Leemput"""
 __email__ = 'silvandeleemput@gmail.com'
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 
 from memcnn.models.revop import ReversibleBlock, InvertibleModuleWrapper, create_coupling, is_invertible_module

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -383,7 +383,7 @@ def is_invertible_module(module_in, test_input_shape, test_input_dtype=torch.flo
             return False
 
         test_reconstructed_inputs = _pack_if_no_tuple(module_in.inverse(*test_outputs))
- 
+
     def _test_shared(inputs, outputs, msg):
         shared = set(inputs)
         shared_outputs = set(outputs)

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -137,13 +137,13 @@ class InvertibleModuleWrapper(nn.Module):
 
         Parameters
         ----------
-            xin : :obj:`torch.Tensor`
-                Input torch tensor.
+            *xin : :obj:`torch.Tensor` tuple
+                Input torch tensor(s).
 
         Returns
         -------
-            :obj:`torch.Tensor`
-                Output torch tensor y.
+            :obj:`torch.Tensor` tuple
+                Output torch tensor(s) *y.
 
         """
         if not self.disable:
@@ -179,13 +179,13 @@ class InvertibleModuleWrapper(nn.Module):
 
         Parameters
         ----------
-            yin : :obj:`torch.Tensor`
-                Input torch tensor.
+            *yin : :obj:`torch.Tensor` tuple
+                Input torch tensor(s).
 
         Returns
         -------
-            :obj:`torch.Tensor`
-                Output torch tensor x.
+            :obj:`torch.Tensor` tuple
+                Output torch tensor(s) *x.
 
         """
         if not self.disable:

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -369,17 +369,17 @@ def is_invertible_module(module_in, test_input_shape, test_input_dtype=torch.flo
     with torch.no_grad():
         torch.manual_seed(random_seed)
         test_inputs = tuple([torch.rand(shape, dtype=test_input_dtype) for shape in test_input_shape])
-        if any([torch.equal(torch.zeros_like(e), e) for e in test_inputs]):
+        if any([torch.equal(torch.zeros_like(e), e) for e in test_inputs]):  # pragma: no cover
             warnings.warn("Some inputs were detected to be all zeros, you might want to set a different random_seed.")
 
         if not _check_inputs_allclose(_pack_if_no_tuple(module_in.inverse(*_pack_if_no_tuple(module_in(*test_inputs)))), test_inputs, atol=atol):
             return False
 
         test_outputs = _pack_if_no_tuple(module_in(*test_inputs))
-        if any([torch.equal(torch.zeros_like(e), e) for e in test_outputs]):
+        if any([torch.equal(torch.zeros_like(e), e) for e in test_outputs]):  # pragma: no cover
             warnings.warn("Some outputs were detected to be all zeros, you might want to set a different random_seed.")
 
-        if not _check_inputs_allclose(_pack_if_no_tuple(module_in(*_pack_if_no_tuple(module_in.inverse(*test_outputs)))), test_outputs, atol=atol):
+        if not _check_inputs_allclose(_pack_if_no_tuple(module_in(*_pack_if_no_tuple(module_in.inverse(*test_outputs)))), test_outputs, atol=atol):  # pragma: no cover
             return False
 
         test_reconstructed_inputs = _pack_if_no_tuple(module_in.inverse(*test_outputs))
@@ -387,7 +387,7 @@ def is_invertible_module(module_in, test_input_shape, test_input_dtype=torch.flo
     def _test_shared(inputs, outputs, msg):
         shared = set(inputs)
         shared_outputs = set(outputs)
-        if len(inputs) != len(shared):
+        if len(inputs) != len(shared):  # pragma: no cover
             warnings.warn("Some inputs (*x) share the same tensor, are you sure this is what you want? ({})".format(msg))
         if len(outputs) != len(shared_outputs):
             warnings.warn("Some outputs (*y) share the same tensor, are you sure this is what you want? ({})".format(msg))

--- a/memcnn/models/tests/test_couplings.py
+++ b/memcnn/models/tests/test_couplings.py
@@ -5,7 +5,8 @@ import copy
 import warnings
 
 from memcnn import create_coupling, InvertibleModuleWrapper
-from memcnn.models.tests.test_revop import set_seeds, SubModule
+from memcnn.models.tests.test_revop import set_seeds
+from memcnn.models.tests.test_models import SubModule
 from memcnn.models.affine import AffineAdapterNaive, AffineBlock
 from memcnn.models.additive import AdditiveBlock
 

--- a/memcnn/models/tests/test_is_invertible_module.py
+++ b/memcnn/models/tests/test_is_invertible_module.py
@@ -1,0 +1,85 @@
+import pytest
+import torch
+
+from memcnn import is_invertible_module, InvertibleModuleWrapper, AdditiveCoupling
+from memcnn.models.tests.test_models import IdentityInverse, MultiSharedOutputs, SubModule
+
+
+def test_is_invertible_module_with_invalid_inverse():
+    fn = IdentityInverse(multiply_inverse=True)
+    with torch.no_grad():
+        fn.factor.zero_()
+    assert not is_invertible_module(fn, test_input_shape=(12, 12))
+
+
+@pytest.mark.parametrize("random_seed", [1, 42, 900000])
+def test_is_invertible_module_random_seeds(random_seed):
+    fn = IdentityInverse(multiply_forward=True, multiply_inverse=True)
+    assert is_invertible_module(fn, test_input_shape=(1, ), random_seed=random_seed)
+
+
+def test_is_invertible_module_shared_outputs():
+    fnb = MultiSharedOutputs()
+    X = torch.rand(1, 2, 5, 5, dtype=torch.float32).requires_grad_()
+    with pytest.warns(UserWarning):
+        assert is_invertible_module(fnb, test_input_shape=(X.shape,), atol=1e-6)
+
+
+def test_is_invertible_module_shared_tensors():
+    fn = IdentityInverse()
+    rm = InvertibleModuleWrapper(fn=fn, keep_input=True, keep_input_inverse=True)
+    X = torch.rand(1, 2, 5, 5, dtype=torch.float32).requires_grad_()
+    with pytest.warns(UserWarning):
+        assert is_invertible_module(fn, test_input_shape=X.shape, atol=1e-6)
+    rm.forward(X)
+    fn.multiply_forward = True
+    rm.forward(X)
+    with pytest.warns(UserWarning):
+        assert is_invertible_module(fn, test_input_shape=X.shape, atol=1e-6)
+    rm.inverse(X)
+    fn.multiply_inverse = True
+    rm.inverse(X)
+    assert is_invertible_module(fn, test_input_shape=X.shape, atol=1e-6)
+
+
+def test_is_invertible_module():
+    X = torch.zeros(1, 10, 10, 10)
+    assert not is_invertible_module(torch.nn.Conv2d(10, 10, kernel_size=(1, 1)),
+                                    test_input_shape=X.shape)
+    fn = AdditiveCoupling(SubModule(), implementation_bwd=-1, implementation_fwd=-1)
+    assert is_invertible_module(fn, test_input_shape=X.shape)
+    class FakeInverse(torch.nn.Module):
+        def forward(self, x):
+            return x * 4
+
+        def inverse(self, y):
+            return y * 8
+    assert not is_invertible_module(FakeInverse(), test_input_shape=X.shape)
+
+
+def test_is_invertible_module_wrapped():
+    X = torch.zeros(1, 10, 10, 10)
+    assert not is_invertible_module(InvertibleModuleWrapper(torch.nn.Conv2d(10, 10, kernel_size=(1, 1))),
+                                    test_input_shape=X.shape)
+    fn = InvertibleModuleWrapper(AdditiveCoupling(SubModule(), implementation_bwd=-1, implementation_fwd=-1))
+    assert is_invertible_module(fn, test_input_shape=X.shape)
+    class FakeInverse(torch.nn.Module):
+        def forward(self, x):
+            return x * 4
+
+        def inverse(self, y):
+            return y * 8
+    assert not is_invertible_module(InvertibleModuleWrapper(FakeInverse()), test_input_shape=X.shape)
+
+
+@pytest.mark.parametrize("input_shape", (
+    "string",
+    (2.3, 1.4),
+    None,
+    True,
+    ((1, 3, ), (12.4)),
+    ((1, 3, ), False)
+))
+def test_is_invertible_module_type_check_input_shapes(input_shape):
+    with pytest.raises(ValueError):
+        is_invertible_module(module_in=IdentityInverse(multiply_forward=True, multiply_inverse=True), test_input_shape=input_shape)

--- a/memcnn/models/tests/test_memory_saving.py
+++ b/memcnn/models/tests/test_memory_saving.py
@@ -3,7 +3,7 @@ import gc
 import numpy as np
 import torch
 import torch.nn
-from memcnn.models.tests.test_revop import SubModuleStack, SubModule
+from memcnn.models.tests.test_models import SubModule, SubModuleStack
 
 
 @pytest.mark.parametrize('coupling', ['additive', 'affine'])

--- a/memcnn/models/tests/test_models.py
+++ b/memcnn/models/tests/test_models.py
@@ -1,0 +1,76 @@
+import torch
+import torch.nn
+
+from memcnn import create_coupling, InvertibleModuleWrapper
+
+
+class MultiplicationInverse(torch.nn.Module):
+    def __init__(self, factor=2):
+        super(MultiplicationInverse, self).__init__()
+        self.factor = torch.nn.Parameter(torch.ones(1) * factor)
+
+    def forward(self, x):
+        return x * self.factor
+
+    def inverse(self, y):
+        return y / self.factor
+
+
+class IdentityInverse(torch.nn.Module):
+    def __init__(self, multiply_forward=False, multiply_inverse=False):
+        super(IdentityInverse, self).__init__()
+        self.factor = torch.nn.Parameter(torch.ones(1))
+        self.multiply_forward = multiply_forward
+        self.multiply_inverse = multiply_inverse
+
+    def forward(self, x):
+        if self.multiply_forward:
+            return x * self.factor
+        else:
+            return x
+
+    def inverse(self, y):
+        if self.multiply_inverse:
+            return y * self.factor
+        else:
+            return y
+
+
+class MultiSharedOutputs(torch.nn.Module):
+    def forward(self, x):
+        y = x * x
+        return y, y
+
+    def inverse(self, y, y2):
+        x = torch.max(torch.sqrt(y), torch.sqrt(y2))
+        return x
+
+
+class SubModule(torch.nn.Module):
+    def __init__(self, in_filters=5, out_filters=5):
+        super(SubModule, self).__init__()
+        self.bn = torch.nn.BatchNorm2d(out_filters)
+        self.conv = torch.nn.Conv2d(in_filters, out_filters, (3, 3), padding=1)
+
+    def forward(self, x):
+        return self.bn(self.conv(x))
+
+
+class SubModuleStack(torch.nn.Module):
+    def __init__(self, Gm, coupling='additive', depth=10, implementation_fwd=-1, implementation_bwd=-1,
+                 keep_input=False, adapter=None, num_bwd_passes=1):
+        super(SubModuleStack, self).__init__()
+        fn = create_coupling(Fm=Gm, Gm=Gm, coupling=coupling, implementation_fwd=implementation_fwd, implementation_bwd=implementation_bwd, adapter=adapter)
+        self.stack = torch.nn.ModuleList(
+            [InvertibleModuleWrapper(fn=fn, keep_input=keep_input, keep_input_inverse=keep_input, num_bwd_passes=num_bwd_passes) for _ in range(depth)]
+        )
+
+    def forward(self, x):
+        for rev_module in self.stack:
+            x = rev_module.forward(x)
+        return x
+
+    def inverse(self, y):
+        for rev_module in reversed(self.stack):
+            y = rev_module.inverse(y)
+        return y

--- a/memcnn/models/tests/test_models.py
+++ b/memcnn/models/tests/test_models.py
@@ -74,3 +74,29 @@ class SubModuleStack(torch.nn.Module):
         for rev_module in reversed(self.stack):
             y = rev_module.inverse(y)
         return y
+
+
+class SplitChannels(torch.nn.Module):
+    def __init__(self, split_location):
+        self.split_location = split_location
+        super(SplitChannels, self).__init__()
+
+    def forward(self, x):
+        return (x[:, :self.split_location, :].clone(),
+                x[:, self.split_location:, :].clone())
+
+    def inverse(self, x, y):
+        return torch.cat([x, y], dim=1)
+
+
+class ConcatenateChannels(torch.nn.Module):
+    def __init__(self, split_location):
+        self.split_location = split_location
+        super(ConcatenateChannels, self).__init__()
+
+    def forward(self, x, y):
+        return torch.cat([x, y], dim=1)
+
+    def inverse(self, x):
+        return (x[:, :self.split_location, :].clone(),
+                x[:, self.split_location:, :].clone())

--- a/memcnn/models/tests/test_multi.py
+++ b/memcnn/models/tests/test_multi.py
@@ -1,32 +1,7 @@
 import pytest
 import torch
 from memcnn.models.revop import InvertibleModuleWrapper, is_invertible_module
-
-
-class SplitChannels(torch.nn.Module):
-    def __init__(self, split_location):
-        self.split_location = split_location
-        super(SplitChannels, self).__init__()
-
-    def forward(self, x):
-        return (x[:, :self.split_location, :].clone(),
-                x[:, self.split_location:, :].clone())
-
-    def inverse(self, x, y):
-        return torch.cat([x, y], dim=1)
-
-
-class ConcatenateChannels(torch.nn.Module):
-    def __init__(self, split_location):
-        self.split_location = split_location
-        super(ConcatenateChannels, self).__init__()
-
-    def forward(self, x, y):
-        return torch.cat([x, y], dim=1)
-
-    def inverse(self, x):
-        return (x[:, :self.split_location, :].clone(),
-                x[:, self.split_location:, :].clone())
+from memcnn.models.tests.test_models import SplitChannels, ConcatenateChannels
 
 
 @pytest.mark.parametrize('disable', [True, False])

--- a/memcnn/models/tests/test_multi.py
+++ b/memcnn/models/tests/test_multi.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+from memcnn.models.revop import InvertibleModuleWrapper
+
+
+class SplitChannels(torch.nn.Module):
+    def __init__(self, split_location):
+        self.split_location = split_location
+        super(SplitChannels, self).__init__()
+
+    def forward(self, x):
+        return (x[:, :self.split_location].clone(),
+                x[:, self.split_location:].clone())
+
+    def inverse(self, x, y):
+        return torch.cat([x, y], dim=1)
+
+
+class ConcatenateChannels(torch.nn.Module):
+    def __init__(self, split_location):
+        self.split_location = split_location
+        super(ConcatenateChannels, self).__init__()
+
+    def forward(self, x, y):
+        return torch.cat([x, y], dim=1)
+
+    def inverse(self, x):
+        return (x[:, :self.split_location].clone(),
+                x[:, self.split_location:].clone())
+
+@pytest.mark.parametrize('disable', [True, False])
+def test_multi(disable):
+    split = InvertibleModuleWrapper(SplitChannels(2), disable = disable)
+    concat = InvertibleModuleWrapper(ConcatenateChannels(2), disable = disable)
+
+    conv_a = torch.nn.Conv2d(2, 2, 3)
+    conv_b = torch.nn.Conv2d(1, 1, 3)
+
+    x = torch.rand(1, 3, 32, 32)
+    x.requires_grad = True
+
+    a, b = split(x)
+    a, b = conv_a(a), conv_b(b)
+    y = concat(a, b)
+    loss = torch.sum(y)
+    loss.backward()
+

--- a/memcnn/models/tests/test_multi.py
+++ b/memcnn/models/tests/test_multi.py
@@ -35,7 +35,7 @@ def test_multi(disable):
     concat = InvertibleModuleWrapper(ConcatenateChannels(2), disable = disable)
 
     assert is_invertible_module(split, test_input_shape=(1, 3, 32, 32))
-    # assert is_invertible_module(concat, test_input_shape=((1, 3, 32, 32), (1, 3, 32, 32)))
+    assert is_invertible_module(concat, test_input_shape=((1, 2, 32, 32), (1, 1, 32, 32)))
 
     conv_a = torch.nn.Conv2d(2, 2, 3)
     conv_b = torch.nn.Conv2d(1, 1, 3)

--- a/memcnn/models/tests/test_revop.py
+++ b/memcnn/models/tests/test_revop.py
@@ -148,11 +148,11 @@ def test_input_output_invertible_function_share_tensor():
     fn = IdentityInverse()
     rm = InvertibleModuleWrapper(fn=fn, keep_input=True, keep_input_inverse=True)
     X = torch.rand(1, 2, 5, 5, dtype=torch.float32).requires_grad_()
-    assert not is_invertible_module(fn, test_input_shape=X.shape, atol=1e-6)
+    assert is_invertible_module(fn, test_input_shape=X.shape, atol=1e-6)
     rm.forward(X)
     fn.multiply_forward = True
     rm.forward(X)
-    assert not is_invertible_module(fn, test_input_shape=X.shape, atol=1e-6)
+    assert is_invertible_module(fn, test_input_shape=X.shape, atol=1e-6)
     rm.inverse(X)
     fn.multiply_inverse = True
     rm.inverse(X)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.1
+current_version = 1.3.2
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.install import install
 from setuptools import find_packages
 
 # circleci.py version
-VERSION = '1.3.1'
+VERSION = '1.3.2'
 
 with open('README.rst', 'r') as fh:
     long_description = fh.read().split('Results\n-------')[0]


### PR DESCRIPTION
Closes #43 

### What was the problem?

InvertibleModuleWrapper only allowed single-input, single-output layers.

### How this PR fixes the problem?

Inputs can now be of the signature *x, outputs are tuples for multi-output layers.

### Check lists (check `x` in `[ ]` of list items)

- [ x] Coding style (indentation, etc)