### PR TITLE
Remove Python2, torch 0.4 and add torch1.7 CI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
     parameters:
       tests:
         type: string
-        default: py27-torch04,py27-torch10,py27-torch11,py37-torch04,py37-torch10,py37-torch11,py37-torch14
+        default: py37-torch10,py37-torch11,py37-torch14,py37-torch17,py37-torchlatest
     <<: *container_python
     steps:
       - checkout
@@ -55,7 +55,7 @@ jobs:
     parameters:
       versions:
         type: string
-        default: "2.7 3.6 3.7"
+        default: "3.6 3.7"
     docker:
       - image: continuumio/miniconda3
     steps:
@@ -146,30 +146,6 @@ workflows:
   build_test_and_deploy:
     jobs:
       - testing:
-          name: testing_py27_torch04
-          tests: py27-torch04
-          filters:
-            tags:
-              only: /.*/
-      - testing:
-          name: testing_py27_torch10
-          tests: py27-torch10
-          filters:
-            tags:
-              only: /.*/
-      - testing:
-          name: testing_py27_torch11
-          tests: py27-torch11
-          filters:
-            tags:
-              only: /.*/
-      - testing:
-          name: testing_py37_torch04
-          tests: py37-torch04
-          filters:
-            tags:
-              only: /.*/
-      - testing:
           name: testing_py37_torch10
           tests: py37-torch10
           filters:
@@ -187,25 +163,25 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - testing:
+          name: testing_py37_torch17
+          tests: py37-torch17
+          filters:
+            tags:
+              only: /.*/
+      - testing:
+          name: testing_py37_torchlatest
+          tests: py37-torchlatest
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
-            - testing_py27_torch04
-            - testing_py27_torch10
-            - testing_py27_torch11
-            - testing_py37_torch04
             - testing_py37_torch10
             - testing_py37_torch11
             - testing_py37_torch14
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)*/
-            branches:
-              ignore: /.*/
-      - conda_deploy:
-          name: conda_deploy_py27
-          versions: "2.7"
-          requires:
-            - deploy
+            - testing_py37_torch17
+            - testing_py37_torchlatest
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
 * MemCNN version:
+* PyTorch version:
 * Python version:
 * Operating System:
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Features
 * Simple toggling of memory saving by setting the `keep_input` property of the `InvertibleModuleWrapper`.
 * Turn arbitrary non-linear PyTorch functions into invertible versions using the `AdditiveCoupling` or the `AffineCoupling` classes.
 * Training and evaluation code for reproducing RevNet experiments using MemCNN.
-* CI tests for Python v2.7 and v3.7 and torch v0.4, v1.0, v1.1, and v1.4 with good code coverage.
+* CI tests for Python v3.7 and torch v1.0, v1.1, v1.4 and v1.7 with good code coverage.
 
 Examples
 --------

--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -1,7 +1,7 @@
 Pillow<7.0.0
 numpy
 SimpleITK
-torch>=0.4.0
+torch>=1.0.0
 torchvision
 tqdm
 pathlib2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,9 +21,9 @@ RUN usermod -a -G sudo user
 
 # Install necessary python libraries
 RUN python3.7 -m pip install pip --upgrade
-RUN python3.7 -m pip install torch===1.4.0
-RUN python3.7 -m pip install torchvision===0.5.0
+RUN python3.7 -m pip install pip install torch===1.7.0 torchvision===0.8.1 torchaudio===0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
 RUN python3.7 -m pip install memcnn
+RUN python3.7 -m pip install pytest
 
 # Set MemCNN config file for user environement
 RUN python3.7 -c "import os, shutil, memcnn; path=os.path.join(os.path.dirname(memcnn.__file__), 'config'); shutil.copy(os.path.join(path, 'config.json.example'), os.path.join(path, 'config.json'));"

--- a/memcnn/models/utils.py
+++ b/memcnn/models/utils.py
@@ -1,9 +1,0 @@
-import torch
-
-# for backwards compatibility
-use_context_mans = True
-
-try:
-    pytorch_version_one_and_above = int(torch.__version__[0]) > 0
-except TypeError:
-    pytorch_version_one_and_above = True

--- a/memcnn/utils/stats.py
+++ b/memcnn/utils/stats.py
@@ -32,6 +32,6 @@ def accuracy(output, target, topk=(1,)):
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+        correct_k = correct[:k].contiguous().view(-1).float().sum(dim=0, keepdim=True)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Pillow<7.0.0
 numpy
 SimpleITK
-torch>=0.4.0
+torch>=1.0.0
 torchvision
 tqdm
 pathlib2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist={py27,py37}-torch{04,10,11,14},release,docs
+envlist={py37}-torch{10,11,14,17,latest},release,docs
 skipsdist=True
 
 [testenv]
@@ -14,14 +14,16 @@ deps=
     pytest
     pytest-cov
     pathlib2
-    torch04: torch>=0.4.0,<0.5
-    torch04: torchvision>=0.1,<0.3
     torch10: torch==1.0.0
     torch10: torchvision>=0.1,<0.3
     torch11: torch==1.1.0
     torch11: torchvision>=0.1,<0.4
     torch14: torch==1.4.0
     torch14: torchvision==0.5.0
+    torch17: torch==1.7.0
+    torch17: torchvision===0.8.1
+    torchlatest: torch
+    torchlatest: torchvision
 
 [testenv:release]
 deps=


### PR DESCRIPTION
Closes #58 

This PR implements:

* Added torch 1.7 to tests, also an automatic latest version build
* Made the Dockerfile use torch 1.7
* Removed all Python2 tests from CI (support has been dropped, time to move on)
* Removed all torch 0.4 tests from CI
* Made test compatible with PyTorch 1.7 (stats.py::accuracy method fix)
* Adjusted the README.rst