### PR TITLE
57 add mixed precision support

### DIFF
--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -1,10 +1,23 @@
+import functools
+
 import warnings
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.cuda.amp import custom_fwd, custom_bwd
+
 from memcnn.models.additive import AdditiveCoupling
 from memcnn.models.affine import AffineCoupling
+
+try:
+    from torch.cuda.amp import custom_fwd, custom_bwd
+except ModuleNotFoundError:
+    def custom_fwd(fwd=None, *, cast_inputs=None):
+        if fwd is None:
+            return functools.partial(custom_fwd)
+        return functools.partial(fwd)
+
+    def custom_bwd(bwd):
+        return functools.partial(bwd)
 
 
 class InvertibleCheckpointFunction(torch.autograd.Function):

--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -1,5 +1,4 @@
 import functools
-
 import warnings
 import numpy as np
 import torch
@@ -153,7 +152,7 @@ class InvertibleModuleWrapper(nn.Module):
 
             disable : :obj:`bool`, optional
                 This will disable using the InvertibleCheckpointFunction altogether.
-                Essentially this renders the function as `y = fn(x)` without any of the memory savings.
+                Essentially this renders the function as :math:`y = fn(x)` without any of the memory savings.
                 Setting this to true will also ignore the keep_input and keep_input_inverse properties.
 
             preserve_rng_state : :obj:`bool`, optional
@@ -171,6 +170,13 @@ class InvertibleModuleWrapper(nn.Module):
             keep_input_inverse : :obj:`bool`, optional
                 Set to retain the input information on inverse, by default it can be discarded since it will be
                 reconstructed upon the backward pass.
+
+        Note
+        ----
+            The InvertibleModuleWrapper can be used with mixed-precision training using
+            :obj:`torch.cuda.amp.autocast` as of torch v1.6 and above. However, inputs will always be cast
+            to :obj:`torch.float32` internally. This is done to minimize autocasting inputs to a different datatype
+            which usually results in a disconnected computation graph and will raise an error on the backward pass.
 
         """
         super(InvertibleModuleWrapper, self).__init__()

--- a/memcnn/models/tests/test_amp.py
+++ b/memcnn/models/tests/test_amp.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+from torch import nn
+import torch.optim as optim
+from torch.cuda.amp import autocast, GradScaler
+
+import torchvision
+from torch.utils.checkpoint import checkpoint
+from torchvision.models.resnet import resnet18, BasicBlock
+import torchvision.transforms as transforms
+
+import memcnn
+
+
+class InvertibleBlock(nn.Module):
+    def __init__(self, block, keep_input, enabled=True):
+        """The input block should already be split across channels
+        """
+        super().__init__()
+        # self.invertible_module = memcnn.AdditiveCoupling(block)
+        self.invertible_block = memcnn.InvertibleModuleWrapper(fn=memcnn.AdditiveCoupling(block),
+                                                               keep_input=keep_input,
+                                                               keep_input_inverse=keep_input, disable=not enabled)
+
+    def forward(self, x, inverse=False):
+        # return checkpoint(self.invertible_module.forward, x)
+        if inverse:
+            return self.invertible_block.inverse(x)
+        else:
+            return self.invertible_block(x)
+
+
+@pytest.mark.parametrize("inv_enabled", (True,))
+@pytest.mark.parametrize("amp_enabled", (False, True))
+def test_cuda_amp(tmp_path, inv_enabled, amp_enabled):
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    model = resnet18(num_classes=10)
+    transform = transforms.Compose(
+        [transforms.ToTensor(),
+         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+    trainset = torchvision.datasets.CIFAR10(root=tmp_path, train=True,
+                                            download=True, transform=transform)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
+                                              shuffle=True, num_workers=2)
+
+    # Replace with invertible blocks
+    model.layer1 = nn.Sequential(
+        InvertibleBlock(BasicBlock(32, 32), keep_input=False, enabled=inv_enabled),
+        InvertibleBlock(BasicBlock(32, 32), keep_input=False, enabled=inv_enabled)
+    )
+
+    model.to(device)
+    # if amp_enabled:
+    #     model.half()
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
+    scaler = GradScaler(enabled=amp_enabled)
+
+    running_loss = 0.0
+
+    for i, data in enumerate(trainloader):
+
+        # -------- AMP ----------
+        inputs, labels = data
+        inputs, labels = inputs.to(device), labels.to(device)
+
+        optimizer.zero_grad()
+        with autocast(enabled=amp_enabled):
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+        # loss.backward()
+        # optimizer.step()
+        scaler.scale(loss).backward()
+        scaler.step(optimizer)
+        scaler.update()
+        # -----------------------
+
+        running_loss += loss.item()
+
+        break

--- a/memcnn/models/tests/test_amp.py
+++ b/memcnn/models/tests/test_amp.py
@@ -2,7 +2,6 @@ import pytest
 import torch
 from torch import nn
 import torch.optim as optim
-from torch.cuda.amp import autocast, GradScaler
 
 import torchvision
 from torch.utils.checkpoint import checkpoint
@@ -11,58 +10,80 @@ import torchvision.transforms as transforms
 
 import memcnn
 
+try:
+    from torch.cuda.amp import autocast, GradScaler
+except ModuleNotFoundError:
+    pass
+
 
 class InvertibleBlock(nn.Module):
     def __init__(self, block, keep_input, enabled=True):
-        """The input block should already be split across channels
-        """
         super().__init__()
-        # self.invertible_module = memcnn.AdditiveCoupling(block)
-        self.invertible_block = memcnn.InvertibleModuleWrapper(fn=memcnn.AdditiveCoupling(block),
-                                                               keep_input=keep_input,
-                                                               keep_input_inverse=keep_input, disable=not enabled)
+        self.invertible_block = memcnn.InvertibleModuleWrapper(
+            fn=memcnn.AdditiveCoupling(block),
+            keep_input=keep_input,
+            keep_input_inverse=keep_input,
+            disable=not enabled,
+        )
 
     def forward(self, x, inverse=False):
-        # return checkpoint(self.invertible_module.forward, x)
         if inverse:
             return self.invertible_block.inverse(x)
         else:
             return self.invertible_block(x)
 
 
-@pytest.mark.parametrize("inv_enabled", (True,))
+class CheckPointBlock(nn.Module):
+    def __init__(self, block):
+        super().__init__()
+        self.invertible_module = memcnn.AdditiveCoupling(block)
+
+    def forward(self, x, inverse=False):
+        return checkpoint(self.invertible_module.forward, x)
+
+
+@pytest.mark.skipif(
+    condition="autocast" not in locals(),
+    reason="torch.cuda.amp could not be found. torch version is < 1.6.",
+)
+@pytest.mark.parametrize(
+    "use_checkpointing, inv_enabled", ((True, False), (False, True,), (False, False))
+)
 @pytest.mark.parametrize("amp_enabled", (False, True))
-def test_cuda_amp(tmp_path, inv_enabled, amp_enabled):
+def test_cuda_amp(tmp_path, inv_enabled, amp_enabled, use_checkpointing):
+    if not torch.cuda.is_available() and amp_enabled:
+        pytest.skip("This test requires a GPU to be available")
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     model = resnet18(num_classes=10)
     transform = transforms.Compose(
-        [transforms.ToTensor(),
-         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
-    trainset = torchvision.datasets.CIFAR10(root=tmp_path, train=True,
-                                            download=True, transform=transform)
-    trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
-                                              shuffle=True, num_workers=2)
-
-    # Replace with invertible blocks
-    model.layer1 = nn.Sequential(
-        InvertibleBlock(BasicBlock(32, 32), keep_input=False, enabled=inv_enabled),
-        InvertibleBlock(BasicBlock(32, 32), keep_input=False, enabled=inv_enabled)
+        [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
+    )
+    trainset = torchvision.datasets.CIFAR10(
+        root=tmp_path, train=True, download=True, transform=transform
+    )
+    trainloader = torch.utils.data.DataLoader(
+        trainset, batch_size=4, shuffle=True, num_workers=2
     )
 
+    # Replace layer1
+    if not use_checkpointing:
+        model.layer1 = nn.Sequential(
+            InvertibleBlock(BasicBlock(32, 32), keep_input=False, enabled=inv_enabled),
+            InvertibleBlock(BasicBlock(32, 32), keep_input=False, enabled=inv_enabled),
+        )
+    else:
+        model.layer1 = nn.Sequential(
+            CheckPointBlock(BasicBlock(32, 32)), CheckPointBlock(BasicBlock(32, 32))
+        )
+
     model.to(device)
-    # if amp_enabled:
-    #     model.half()
 
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
     scaler = GradScaler(enabled=amp_enabled)
 
-    running_loss = 0.0
-
     for i, data in enumerate(trainloader):
-
-        # -------- AMP ----------
         inputs, labels = data
         inputs, labels = inputs.to(device), labels.to(device)
 
@@ -70,13 +91,7 @@ def test_cuda_amp(tmp_path, inv_enabled, amp_enabled):
         with autocast(enabled=amp_enabled):
             outputs = model(inputs)
             loss = criterion(outputs, labels)
-        # loss.backward()
-        # optimizer.step()
-        scaler.scale(loss).backward()
+            scaler.scale(loss).backward()
         scaler.step(optimizer)
         scaler.update()
-        # -----------------------
-
-        running_loss += loss.item()
-
         break

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(
     install_requires=requirements,
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Closes #57

### What was the problem?

Mixed precision training with the newly introduced `torch.cuda.amp.autocast` context manager gave some errors.
See #57 for a detailed description of the problem.

### How this PR fixes the problem?

* It adds `torch.cuda.amp` decorators @custom_fwd and @custom_bwd to the forward and backward methods of the `InvertibleCheckpointFunction` and fixes the input cast to `torch.float32`. This isn't perfect, but the best we can do here for now and it fixes the problem.
* A note has been added to the InvertibleModuleWrapper explaining the float32 conversion for mixed-precision training.
* Dummy decorators are used for PyTorch versions < 1.6

### Check lists 

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

There might be a better solution out there, it is also good to keep up-to-date with: 
https://github.com/pytorch/pytorch/issues/37730