### PR TITLE
removing the deprecation message

### DIFF
--- a/memcnn/models/revop.py
+++ b/memcnn/models/revop.py
@@ -7,16 +7,25 @@ import torch.nn as nn
 from memcnn.models.additive import AdditiveCoupling
 from memcnn.models.affine import AffineCoupling
 
+
 try:
-    from torch.cuda.amp import custom_fwd, custom_bwd
-except ModuleNotFoundError:
-    def custom_fwd(fwd=None, *, cast_inputs=None):
+    import torch.amp
+    def custom_fwd(fwd=None, *, cast_inputs=None, device_type='cuda'):
         if fwd is None:
-            return functools.partial(custom_fwd)
+            return functools.partial(custom_fwd, cast_inputs=cast_inputs, device_type=device_type)
+        return torch.amp.custom_fwd(fwd, cast_inputs=cast_inputs, device_type=device_type)
+    def custom_bwd(bwd, device_type='cuda'):
+        return torch.amp.custom_bwd(bwd, device_type=device_type)
+
+except ModuleNotFoundError:
+    def custom_fwd(fwd=None, *, cast_inputs=None, device_type='cuda'):
+        if fwd is None:
+            return functools.partial(custom_fwd, cast_inputs=cast_inputs, device_type=device_type)
         return functools.partial(fwd)
 
-    def custom_bwd(bwd):
-        return functools.partial(bwd)
+    def custom_bwd(bwd, device_type='cuda'):
+        return functools.partial(bwd, device_type=device_type)
+
 
 
 class InvertibleCheckpointFunction(torch.autograd.Function):


### PR DESCRIPTION
I am not totally sure I fixed it correctly tested very briefly with ipython with both cuda enabled and disabled (by setting cuda visible devices):   
```python
import torch,iunets
n=iunets.iUNet(17,[32, 64, 128], dim=2)
s=n(torch.rand(7,17,100,101)).sum()
s.backward()
```
and 
```python
import torch,iunets
n=iunets.iUNet(17,[32, 64, 128], dim=2).to('cuda') s=n(torch.rand(7,17,100,101,device='cuda')).sum()
s.backward()
```

### What was the problem?

Whenever I imported Iunets (which depends  on memcnn) I used to get two future warnings:``` FutureWarning: `torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.
  @custom_fwd(cast_inputs=torch.float32)
...... /memcnn/models/revop.py:73: FutureWarning: `torch.cuda.amp.custom_bwd(args...)` is deprecated. Please use `torch.amp.custom_bwd(args..., device_type='cuda')` instead.
  @custom_bwd
``` 

### How this PR fixes the problem?

The future warning on import is no longer appearing

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

My test was extremely naive essentially naive. I have a small doudpt a few lines are redundant (the import exception no longer makes sence). I am not sure if Using the import exception is in order I did it to be as close as posible to the original design. It might well be that the whole try/catch is pointless.